### PR TITLE
Ignore fixtures and ci dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+/.ci
 
 **/alembic.ini
 server/tests/db.sqlite

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,11 @@ $(MAKEFILE):
 	git clone --quiet --depth 1 -b $(CI_BRANCH) $(CI_REPOSITORY) $(CI_PATH);
 -include $(MAKEFILE)
 
+IO_DIR ?= $(PWD)/server/tests
+
 db.sqlite:
-	docker run --rm -e DB_DIR=/io -v$(PWD):/io --entrypoint python3 $(IMAGE) /server/tests/gen_sqlite_db.py
+	docker run --rm -e DB_DIR=/io -v$(IO_DIR):/io --entrypoint python3 $(IMAGE) /server/tests/gen_sqlite_db.py
 
 .PHONY: run-api
 run-api: db.sqlite
-	docker run --rm -p 8080:8080 -v$(PWD):/io $(IMAGE) --ui --metadata-db=sqlite:///io/db.sqlite --state-db=sqlite://
+	docker run --rm -p 8080:8080 -v$(IO_DIR):/io $(IMAGE) --ui --metadata-db=sqlite:///io/db.sqlite --state-db=sqlite://


### PR DESCRIPTION
Before this PR is merged, the `db.sqlite` is generated in a place out of the `.gitignore`, so it tries to be committed. If this PR is merged, it will be generated as the `.gitignore` expects.