### PR TITLE
Add Sentry conf to docs and 'make run-api'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,15 @@ $(MAKEFILE):
 -include $(MAKEFILE)
 
 IO_DIR ?= $(PWD)/server/tests
+ENV_FILE ?= .env
 
-db.sqlite:
-	docker run --rm -e DB_DIR=/io -v$(IO_DIR):/io --entrypoint python3 $(IMAGE) /server/tests/gen_sqlite_db.py
+$(ENV_FILE):
+	echo 'SENTRY_PROJECT=' >> $(ENV_FILE)
+	echo 'SENTRY_KEY=' >> $(ENV_FILE)
+
+db.sqlite: $(ENV_FILE)
+	docker run --rm -e DB_DIR=/io -v$(IO_DIR):/io --env-file $(ENV_FILE) --entrypoint python3 $(IMAGE) /server/tests/gen_sqlite_db.py
 
 .PHONY: run-api
-run-api: db.sqlite
-	docker run --rm -p 8080:8080 -v$(IO_DIR):/io $(IMAGE) --ui --metadata-db=sqlite:///io/db.sqlite --state-db=sqlite://
+run-api: $(ENV_FILE) db.sqlite
+	docker run --rm -p 8080:8080 -v$(IO_DIR):/io --env-file $(ENV_FILE) $(IMAGE) --ui --metadata-db=sqlite:///io/db.sqlite --state-db=sqlite://

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ ENV_FILE ?= .env
 $(ENV_FILE):
 	echo 'SENTRY_PROJECT=' >> $(ENV_FILE)
 	echo 'SENTRY_KEY=' >> $(ENV_FILE)
+	echo >> $(ENV_FILE)
+	echo 'AUTH0_DOMAIN=' >> $(ENV_FILE)
+	echo 'AUTH0_AUDIENCE=' >> $(ENV_FILE)
 
 db.sqlite: $(ENV_FILE)
 	docker run --rm -e DB_DIR=/io -v$(IO_DIR):/io --env-file $(ENV_FILE) --entrypoint python3 $(IMAGE) /server/tests/gen_sqlite_db.py

--- a/server/README.md
+++ b/server/README.md
@@ -80,6 +80,14 @@ make run-api
 
 And open http://localhost:8080/v1/ui
 
+
+## Configure Sentry
+
+You can set `SENTRY_PROJECT` and `SENTRY_KEY` environment variables to automatically send the local server crashes to Sentry.
+
+If you're running the API with docker (using `make run-api` from above), you should stop the server, add the Sentry values into the `.env` file that will be in the root folder of `athenian-api`, and start the server again (with `make run-api`).
+
+
 ## Prevent file overriding
 
 After the first generation, add edited files to _.openapi-generator-ignore_ to prevent generator to overwrite them. Typically:


### PR DESCRIPTION
When using `make run-api` an `.env` file will be automatically created with a placeholder for Sentry values. If they're filled with Athenian Sentry account values, issues locally found will be automatically sent to Athenian Sentry account.