### PR TITLE
Fix User short circuit after changing its signature

### DIFF
--- a/server/athenian/api/auth.py
+++ b/server/athenian/api/auth.py
@@ -93,7 +93,7 @@ class Auth0:
             return await handler(request)
 
         # FIXME(vmarkovtsev): remove the following short circuit when the frontend is ready
-        request.user = User("https://github.com/vmarkovtsev", "Vadim Markovtsev",
+        request.user = User("auth0:vmarkovtsev", "vadim@athenian.co", "Vadim Markovtsev",
                             "https://avatars1.githubusercontent.com/u/2793551",
                             "2020-01-08 11:12:04.985028")
         return await handler(request)


### PR DESCRIPTION
Fix [[ENG-140]] after #46

Since #46 changed `User` signature, this commit will use it in the short circuit preparing the user.

I guessed the values for the new `User` from [#46/server/tests/controllers/conftest.py::Line52](https://github.com/athenianco/athenian-api/pull/46/files#diff-e7ee7ee4c3433d161d4e0b9902266965R53)

[ENG-140]: https://athenianco.atlassian.net/browse/ENG-140