### PR TITLE
Help development with clean command and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,14 @@ $(ENV_FILE):
 
 $(IO_DIR)/%.sqlite: $(ENV_FILE)
 	docker run --rm -e DB_DIR=/io -v$(IO_DIR):/io --env-file $(ENV_FILE) --entrypoint python3 $(IMAGE) /server/tests/gen_sqlite_db.py
-	@touch $@
 
 .PHONY: run-api
-
 run-api: $(IO_DIR)/mdb.sqlite $(IO_DIR)/sdb.sqlite
 	docker run --rm -p 8080:8080 -v$(IO_DIR):/io --env-file $(ENV_FILE) $(IMAGE) --ui --metadata-db=sqlite:///io/mdb.sqlite --state-db=sqlite:///io/sdb.sqlite
+
+.PHONY: clean
+clean: fixtures-clean
+
+.PHONY: fixtures-clean
+fixtures-clean:
+	rm -rf $(IO_DIR)/mdb.sqlite $(IO_DIR)/sdb.sqlite

--- a/server/README.md
+++ b/server/README.md
@@ -101,6 +101,18 @@ make run-api
 
 And open http://localhost:8080/v1/ui
 
+If you want to run your own API image, use instead:
+```
+# Run the API container
+IMAGE=your_api_image:tag make run-api
+```
+
+You can erase the API data fixtures created by `make run-api` with:
+```
+make clean
+```
+
+
 
 ## Configure Sentry
 


### PR DESCRIPTION
supersedes #66

to clean local fixtures:
```
$ make clean
```

to run your own API docker image:
```
$ IMAGE=your_api_image:tag make run-api
```
