### PR TITLE
Add bearerAuth in openapi spec for autheniticated path

### DIFF
--- a/server/athenian/api/controllers/security_controller.py
+++ b/server/athenian/api/controllers/security_controller.py
@@ -1,0 +1,20 @@
+from typing import Dict
+
+from jose import jwt
+
+
+def info_from_bearerAuth(token: str) -> Dict[str, str]:
+    """
+    Check and retrieve authentication information from custom bearer token.
+
+    Returned value will be passed in 'token_info' parameter of your operation function, if there
+    is one. 'sub' or 'uid' will be set in 'user' parameter of your operation function, if there
+    is one. Should return None if auth is invalid or does not allow access to called API.
+    """
+    return jwt.decode(
+        token,
+        "athenian",
+        algorithms=["RS256", "HS256"],
+        audience="https://api.owl.athenian.co",
+        issuer="https://athenian.auth0.com/",
+    )

--- a/server/athenian/api/controllers/security_controller.py
+++ b/server/athenian/api/controllers/security_controller.py
@@ -1,7 +1,5 @@
 from typing import Dict
 
-from jose import jwt
-
 
 def info_from_bearerAuth(token: str) -> Dict[str, str]:
     """
@@ -11,6 +9,7 @@ def info_from_bearerAuth(token: str) -> Dict[str, str]:
     is one. 'sub' or 'uid' will be set in 'user' parameter of your operation function, if there
     is one. Should return None if auth is invalid or does not allow access to called API.
     """
+    """
     return jwt.decode(
         token,
         "athenian",
@@ -18,3 +17,5 @@ def info_from_bearerAuth(token: str) -> Dict[str, str]:
         audience="https://api.owl.athenian.co",
         issuer="https://athenian.auth0.com/",
     )
+    """
+    return {}

--- a/server/athenian/api/openapi/openapi.yaml
+++ b/server/athenian/api/openapi/openapi.yaml
@@ -9,8 +9,6 @@ servers:
 paths:
   /account/{id}:
     get:
-      security:
-        - bearerAuth: []
       operationId: get_account
       parameters:
       - description: Numeric identifier of the account to list. The user must belong
@@ -41,13 +39,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: The account was not found.
+      security:
+      - bearerAuth: []
       summary: List the current user's account members.
       x-openapi-router-controller: athenian.api.controllers.user_controller
       x-codegen-request-body-name: body
   /invite/accept:
     put:
-      security:
-        - bearerAuth: []
       operationId: accept_invitation
       requestBody:
         content:
@@ -82,6 +80,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: Invitation was not found.
+      security:
+      - bearerAuth: []
       summary: Accept the account membership invitation and finish registration. The
         user must be already authorized in Auth0.
       x-openapi-router-controller: athenian.api.controllers.invitation_controller
@@ -111,8 +111,6 @@ paths:
       x-codegen-request-body-name: body
   /invite/generate/{id}:
     get:
-      security:
-        - bearerAuth: []
       operationId: gen_invitation
       parameters:
       - description: Numeric identifier of the account where to invite new users.
@@ -142,14 +140,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: The account was not found.
+      security:
+      - bearerAuth: []
       summary: Generate an account invitation link for regular users. The caller must
         be an admin of the specified account.
       x-openapi-router-controller: athenian.api.controllers.invitation_controller
       x-codegen-request-body-name: body
   /metrics_line:
     post:
-      security:
-        - bearerAuth: []
       operationId: calc_metrics_line
       requestBody:
         content:
@@ -185,13 +183,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/NoSourceDataError'
           description: No data is available to calculate metrics for the given repositories.
+      security:
+      - bearerAuth: []
       summary: Calculate metrics.
       x-openapi-router-controller: athenian.api.controllers.metrics_controller
       x-codegen-request-body-name: body
   /reposet/create:
     post:
-      security:
-        - bearerAuth: []
       operationId: create_reposet
       requestBody:
         content:
@@ -213,13 +211,13 @@ paths:
                 $ref: '#/components/schemas/GenericError'
           description: The user is forbidden to create a repository set from the specified
             items.
+      security:
+      - bearerAuth: []
       summary: Create a repository set.
       x-openapi-router-controller: athenian.api.controllers.reposet_controller
       x-codegen-request-body-name: body
   /reposet/{id}:
     delete:
-      security:
-        - bearerAuth: []
       operationId: delete_reposet
       parameters:
       - description: Numeric identifier of the repository set to list.
@@ -249,13 +247,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: The specified repository set was not found.
+      security:
+      - bearerAuth: []
       summary: Delete a repository set. The user must be an admin of the account that
         owns the reposet.
       x-openapi-router-controller: athenian.api.controllers.reposet_controller
       x-codegen-request-body-name: body
     get:
-      security:
-        - bearerAuth: []
       operationId: get_reposet
       parameters:
       - description: Numeric identifier of the repository set to list.
@@ -285,13 +283,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: The specified repository set was not found.
+      security:
+      - bearerAuth: []
       summary: List a repository set. The user must be in the account that owns the
         reposet.
       x-openapi-router-controller: athenian.api.controllers.reposet_controller
       x-codegen-request-body-name: body
     put:
-      security:
-        - bearerAuth: []
       operationId: update_reposet
       parameters:
       - description: Numeric identifier of the repository set to list.
@@ -327,14 +325,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: The specified repository set was not found.
+      security:
+      - bearerAuth: []
       summary: Update a repository set. The user must be an admin of the account that
         owns the reposet.
       x-openapi-router-controller: athenian.api.controllers.reposet_controller
       x-codegen-request-body-name: body
   /reposets/{id}:
     get:
-      security:
-        - bearerAuth: []
       operationId: list_reposets
       parameters:
       - description: Numeric identifier of the account.
@@ -358,13 +356,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: The user does not belong to the specified account.
+      security:
+      - bearerAuth: []
       summary: List the repository sets belonging to the current user.
       x-openapi-router-controller: athenian.api.controllers.reposet_controller
       x-codegen-request-body-name: body
   /user:
     get:
-      security:
-        - bearerAuth: []
       operationId: get_user
       responses:
         200:
@@ -373,6 +371,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/User'
           description: Details about the current user.
+      security:
+      - bearerAuth: []
       summary: Show details about the current user.
       x-openapi-router-controller: athenian.api.controllers.user_controller
       x-codegen-request-body-name: body
@@ -382,6 +382,7 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+      x-bearerInfoFunc: athenian.api.controllers.security_controller.info_from_bearerAuth
   schemas:
     CreatedIdentifier:
       example:

--- a/server/athenian/api/openapi/openapi.yaml
+++ b/server/athenian/api/openapi/openapi.yaml
@@ -9,6 +9,8 @@ servers:
 paths:
   /account/{id}:
     get:
+      security:
+        - bearerAuth: []
       operationId: get_account
       parameters:
       - description: Numeric identifier of the account to list. The user must belong
@@ -44,6 +46,8 @@ paths:
       x-codegen-request-body-name: body
   /invite/accept:
     put:
+      security:
+        - bearerAuth: []
       operationId: accept_invitation
       requestBody:
         content:
@@ -107,6 +111,8 @@ paths:
       x-codegen-request-body-name: body
   /invite/generate/{id}:
     get:
+      security:
+        - bearerAuth: []
       operationId: gen_invitation
       parameters:
       - description: Numeric identifier of the account where to invite new users.
@@ -142,6 +148,8 @@ paths:
       x-codegen-request-body-name: body
   /metrics_line:
     post:
+      security:
+        - bearerAuth: []
       operationId: calc_metrics_line
       requestBody:
         content:
@@ -182,6 +190,8 @@ paths:
       x-codegen-request-body-name: body
   /reposet/create:
     post:
+      security:
+        - bearerAuth: []
       operationId: create_reposet
       requestBody:
         content:
@@ -208,6 +218,8 @@ paths:
       x-codegen-request-body-name: body
   /reposet/{id}:
     delete:
+      security:
+        - bearerAuth: []
       operationId: delete_reposet
       parameters:
       - description: Numeric identifier of the repository set to list.
@@ -242,6 +254,8 @@ paths:
       x-openapi-router-controller: athenian.api.controllers.reposet_controller
       x-codegen-request-body-name: body
     get:
+      security:
+        - bearerAuth: []
       operationId: get_reposet
       parameters:
       - description: Numeric identifier of the repository set to list.
@@ -276,6 +290,8 @@ paths:
       x-openapi-router-controller: athenian.api.controllers.reposet_controller
       x-codegen-request-body-name: body
     put:
+      security:
+        - bearerAuth: []
       operationId: update_reposet
       parameters:
       - description: Numeric identifier of the repository set to list.
@@ -317,6 +333,8 @@ paths:
       x-codegen-request-body-name: body
   /reposets/{id}:
     get:
+      security:
+        - bearerAuth: []
       operationId: list_reposets
       parameters:
       - description: Numeric identifier of the account.
@@ -345,6 +363,8 @@ paths:
       x-codegen-request-body-name: body
   /user:
     get:
+      security:
+        - bearerAuth: []
       operationId: get_user
       responses:
         200:
@@ -357,6 +377,11 @@ paths:
       x-openapi-router-controller: athenian.api.controllers.user_controller
       x-codegen-request-body-name: body
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     CreatedIdentifier:
       example:

--- a/server/tests/controllers/conftest.py
+++ b/server/tests/controllers/conftest.py
@@ -2,8 +2,11 @@ from datetime import datetime
 import logging
 import os
 from pathlib import Path
+import time
+from typing import Dict
 
 
+from jose import jwt
 try:
     import pytest
 except ImportError:
@@ -56,6 +59,25 @@ async def eiso(app) -> User:
     )
     app._auth0.user = user
     return user
+
+
+@pytest.fixture(scope="function")
+def headers() -> Dict[str, str]:
+    timestamp = int(time.time())
+    payload = {
+        "aud": "https://api.owl.athenian.co",
+        "iss": "https://athenian.auth0.com/",
+        "iat": timestamp,
+        "exp": timestamp + 600,
+        "sub": "github|2793551",
+    }
+    token = jwt.encode(payload, "athenian", algorithm="HS256")
+    return {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "Origin": "http://localhost",
+        "Authorization": "Bearer " + token,
+    }
 
 
 @pytest.fixture(scope="function")

--- a/server/tests/controllers/test_cors.py
+++ b/server/tests/controllers/test_cors.py
@@ -1,9 +1,4 @@
-async def test_cors(client):
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-        "Origin": "http://localhost",
-    }
+async def test_cors(client, headers):
     response = await client.request(
         method="GET", path="/v1/reposet/1", headers=headers, json={},
     )

--- a/server/tests/controllers/test_metrics_controller.py
+++ b/server/tests/controllers/test_metrics_controller.py
@@ -8,7 +8,7 @@ from athenian.api.models.web import CalculatedMetrics, Granularity, MetricID
 
 
 @pytest.mark.parametrize("metric", MetricID.ALL)
-async def test_calc_metrics_line_smoke(client, metric):
+async def test_calc_metrics_line_smoke(client, metric, headers):
     """Trivial test to prove that at least something is working."""
     body = {
         "for": [
@@ -33,10 +33,6 @@ async def test_calc_metrics_line_smoke(client, metric):
         "granularity": "week",
         "account": 1,
     }
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
     response = await client.request(
         method="POST", path="/v1/metrics_line", headers=headers, json=body,
     )
@@ -47,7 +43,7 @@ async def test_calc_metrics_line_smoke(client, metric):
 
 
 @pytest.mark.parametrize("granularity", Granularity.ALL)
-async def test_calc_metrics_line_all(client, granularity):
+async def test_calc_metrics_line_all(client, granularity, headers):
     """https://athenianco.atlassian.net/browse/ENG-116"""
     body = {
         "for": [
@@ -71,10 +67,6 @@ async def test_calc_metrics_line_all(client, granularity):
         "date_to": "2019-03-15",
         "granularity": granularity,
         "account": 1,
-    }
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
     }
     response = await client.request(
         method="POST", path="/v1/metrics_line", headers=headers, json=body,
@@ -110,7 +102,7 @@ async def test_calc_metrics_line_all(client, granularity):
 
 @pytest.mark.parametrize(("devs", "date_from"),
                          ([{"developers": []}, "2019-11-28"], [{}, "2018-09-28"]))
-async def test_calc_metrics_line_empty_devs_tight_date(client, devs, date_from):
+async def test_calc_metrics_line_empty_devs_tight_date(client, devs, date_from, headers):
     """https://athenianco.atlassian.net/browse/ENG-126"""
     body = {
         "date_from": date_from,
@@ -126,10 +118,6 @@ async def test_calc_metrics_line_empty_devs_tight_date(client, devs, date_from):
         "account": 1,
         "metrics": list(MetricID.ALL),
     }
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
     response = await client.request(
         method="POST", path="/v1/metrics_line", headers=headers, json=body,
     )
@@ -139,7 +127,7 @@ async def test_calc_metrics_line_empty_devs_tight_date(client, devs, date_from):
     assert len(cm.calculated[0].values) > 0
 
 
-async def test_calc_metrics_line_bad_date(client):
+async def test_calc_metrics_line_bad_date(client, headers):
     """What if we specify a date that does not exist?"""
     body = {
         "for": [
@@ -164,10 +152,6 @@ async def test_calc_metrics_line_bad_date(client):
         "granularity": "week",
         "account": 1,
     }
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
     response = await client.request(
         method="POST", path="/v1/metrics_line", headers=headers, json=body,
     )
@@ -176,7 +160,7 @@ async def test_calc_metrics_line_bad_date(client):
 
 
 @pytest.mark.parametrize("account", [3, 10])
-async def test_calc_metrics_line_reposet_bad_account(client, account):
+async def test_calc_metrics_line_reposet_bad_account(client, account, headers):
     """What if we specify a account that the user does not belong to or does not exist?"""
     body = {
         "for": [
@@ -191,10 +175,6 @@ async def test_calc_metrics_line_reposet_bad_account(client, account):
         "granularity": "week",
         "account": account,
     }
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
     response = await client.request(
         method="POST", path="/v1/metrics_line", headers=headers, json=body,
     )
@@ -202,7 +182,7 @@ async def test_calc_metrics_line_reposet_bad_account(client, account):
     assert response.status == 403, "Response body is : " + body
 
 
-async def test_calc_metrics_line_reposet(client):
+async def test_calc_metrics_line_reposet(client, headers):
     """Substitute {id} with the real repos."""
     body = {
         "for": [
@@ -216,10 +196,6 @@ async def test_calc_metrics_line_reposet(client):
         "date_to": "2020-01-23",
         "granularity": "week",
         "account": 1,
-    }
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
     }
     response = await client.request(
         method="POST", path="/v1/metrics_line", headers=headers, json=body,

--- a/server/tests/controllers/test_repository_set_controller.py
+++ b/server/tests/controllers/test_repository_set_controller.py
@@ -7,12 +7,8 @@ from athenian.api.models.state.models import RepositorySet
 from athenian.api.models.web.repository_set_create_request import RepositorySetCreateRequest
 
 
-async def test_delete_repository_set(client, app):
+async def test_delete_repository_set(client, app, headers):
     body = {}
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
     response = await client.request(
         method="DELETE", path="/v1/reposet/1", headers=headers, json=body,
     )
@@ -22,12 +18,8 @@ async def test_delete_repository_set(client, app):
     assert rs is None
 
 
-async def test_delete_repository_set_404(client, app):
+async def test_delete_repository_set_404(client, app, headers):
     body = {}
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
     response = await client.request(
         method="DELETE", path="/v1/reposet/10", headers=headers, json=body,
     )
@@ -36,12 +28,8 @@ async def test_delete_repository_set_404(client, app):
 
 
 @pytest.mark.parametrize("reposet", [2, 3])
-async def test_delete_repository_set_bad_account(client, reposet):
+async def test_delete_repository_set_bad_account(client, reposet, headers):
     body = {}
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
     response = await client.request(
         method="DELETE", path="/v1/reposet/%d" % reposet, headers=headers, json=body,
     )
@@ -50,12 +38,8 @@ async def test_delete_repository_set_bad_account(client, reposet):
 
 
 @pytest.mark.parametrize("reposet", [1, 2])
-async def test_get_repository_set(client, reposet):
+async def test_get_repository_set(client, reposet, headers):
     body = {}
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
     response = await client.request(
         method="GET", path="/v1/reposet/%d" % reposet, headers=headers, json=body,
     )
@@ -66,12 +50,8 @@ async def test_get_repository_set(client, reposet):
     assert "github.com/athenianco/athenian-api" in body
 
 
-async def test_get_repository_set_404(client):
+async def test_get_repository_set_404(client, headers):
     body = {}
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
     response = await client.request(
         method="GET", path="/v1/reposet/10", headers=headers, json=body,
     )
@@ -79,12 +59,8 @@ async def test_get_repository_set_404(client):
     assert response.status == 404, "Response body is : " + body
 
 
-async def test_get_repository_set_bad_account(client):
+async def test_get_repository_set_bad_account(client, headers):
     body = {}
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
     response = await client.request(
         method="GET", path="/v1/reposet/3", headers=headers, json=body,
     )
@@ -92,12 +68,8 @@ async def test_get_repository_set_bad_account(client):
     assert response.status == 403, "Response body is : " + body
 
 
-async def test_set_repository_set(client):
+async def test_set_repository_set(client, headers):
     body = ["github.com/vmarkovtsev/hercules"]
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
     response = await client.request(
         method="PUT", path="/v1/reposet/1", headers=headers, json=body,
     )
@@ -106,12 +78,8 @@ async def test_set_repository_set(client):
     assert body == '["github.com/vmarkovtsev/hercules"]'
 
 
-async def test_set_repository_set_404(client):
+async def test_set_repository_set_404(client, headers):
     body = ["github.com/vmarkovtsev/hercules"]
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
     response = await client.request(
         method="PUT", path="/v1/reposet/10", headers=headers, json=body,
     )
@@ -120,12 +88,8 @@ async def test_set_repository_set_404(client):
 
 
 @pytest.mark.parametrize("reposet", [2, 3])
-async def test_set_repository_set_bad_account(client, reposet):
+async def test_set_repository_set_bad_account(client, reposet, headers):
     body = ["github.com/vmarkovtsev/hercules"]
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
     response = await client.request(
         method="PUT", path="/v1/reposet/%d" % reposet, headers=headers, json=body,
     )
@@ -133,12 +97,8 @@ async def test_set_repository_set_bad_account(client, reposet):
     assert response.status == 403, "Response body is : " + body
 
 
-async def test_create_repository_set(client):
+async def test_create_repository_set(client, headers):
     body = RepositorySetCreateRequest(1, ["github.com/vmarkovtsev/hercules"]).to_dict()
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
     response = await client.request(
         method="POST", path="/v1/reposet/create", headers=headers, json=body,
     )
@@ -149,12 +109,8 @@ async def test_create_repository_set(client):
 
 
 @pytest.mark.parametrize("account", [2, 3, 10])
-async def test_create_repository_set_bad_account(client, account):
+async def test_create_repository_set_bad_account(client, account, headers):
     body = RepositorySetCreateRequest(account, ["github.com/vmarkovtsev/hercules"]).to_dict()
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
     response = await client.request(
         method="POST", path="/v1/reposet/create", headers=headers, json=body,
     )
@@ -163,11 +119,7 @@ async def test_create_repository_set_bad_account(client, account):
 
 
 @pytest.mark.parametrize("account", [1, 2])
-async def test_list_repository_sets(client, account):
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
+async def test_list_repository_sets(client, account, headers):
     response = await client.request(
         method="GET", path="/v1/reposets/%d" % account, headers=headers, json={},
     )
@@ -181,11 +133,7 @@ async def test_list_repository_sets(client, account):
 
 
 @pytest.mark.parametrize("account", [3, 10])
-async def test_list_repository_sets_bad_account(client, account):
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
+async def test_list_repository_sets_bad_account(client, account, headers):
     response = await client.request(
         method="GET", path="/v1/reposets/%d" % account, headers=headers, json={},
     )

--- a/server/tests/controllers/test_user_controller.py
+++ b/server/tests/controllers/test_user_controller.py
@@ -4,11 +4,7 @@ import json
 import dateutil.parser
 
 
-async def test_get_user(client):
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
+async def test_get_user(client, headers):
     response = await client.request(
         method="GET", path="/v1/user", headers=headers, json={},
     )
@@ -26,11 +22,7 @@ async def test_get_user(client):
     assert datetime.utcnow() >= dateutil.parser.parse(updated[:-1])
 
 
-async def test_get_account(client):
-    headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
+async def test_get_account(client, headers):
     response = await client.request(
         method="GET", path="/v1/account/1", headers=headers, json={},
     )


### PR DESCRIPTION
This change is required for generating the client for making it able to call with bearer token.

I tried generating the python files and on changes occurred.

Reference: https://swagger.io/docs/specification/authentication/bearer-authentication/