### PR TITLE
Admin backdoor index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ $(MAKEFILE):
 	git clone --quiet --depth 1 -b $(CI_BRANCH) $(CI_REPOSITORY) $(CI_PATH);
 -include $(MAKEFILE)
 
+DOCKER_RUN_EXTRA_ARGS ?= -it
+
 IO_DIR ?= $(PWD)/server/tests
 ENV_FILE ?= .env
 
@@ -29,7 +31,8 @@ $(IO_DIR)/%.sqlite: $(ENV_FILE)
 
 .PHONY: run-api
 run-api: $(IO_DIR)/mdb.sqlite $(IO_DIR)/sdb.sqlite
-	docker run --rm -p 8080:8080 -v$(IO_DIR):/io --env-file $(ENV_FILE) $(IMAGE) --ui --metadata-db=sqlite:///io/mdb.sqlite --state-db=sqlite:///io/sdb.sqlite
+	docker run $(DOCKER_RUN_EXTRA_ARGS) --rm -p 8080:8080 -v$(IO_DIR):/io --env-file $(ENV_FILE) $(IMAGE) --ui --metadata-db=sqlite:///io/mdb.sqlite --state-db=sqlite:///io/sdb.sqlite
+
 .PHONY: invitation-link
 invitation-link: $(IO_DIR)/mdb.sqlite $(IO_DIR)/sdb.sqlite
 	docker run --rm -e DB_DIR=/io -v$(IO_DIR):/io --env-file $(ENV_FILE) --entrypoint python3 $(IMAGE) -m athenian.api.invite_admin sqlite:///io/sdb.sqlite

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ $(IO_DIR)/%.sqlite: $(ENV_FILE)
 .PHONY: run-api
 run-api: $(IO_DIR)/mdb.sqlite $(IO_DIR)/sdb.sqlite
 	docker run --rm -p 8080:8080 -v$(IO_DIR):/io --env-file $(ENV_FILE) $(IMAGE) --ui --metadata-db=sqlite:///io/mdb.sqlite --state-db=sqlite:///io/sdb.sqlite
+.PHONY: invitation-link
+invitation-link: $(IO_DIR)/mdb.sqlite $(IO_DIR)/sdb.sqlite
+	docker run --rm -e DB_DIR=/io -v$(IO_DIR):/io --env-file $(ENV_FILE) --entrypoint python3 $(IMAGE) -m athenian.api.invite_admin sqlite:///io/sdb.sqlite
 
 .PHONY: clean
 clean: fixtures-clean

--- a/server/athenian/api/__init__.py
+++ b/server/athenian/api/__init__.py
@@ -43,7 +43,9 @@ def parse_args() -> argparse.Namespace:
   AUTH0_CLIENT_ID          Client ID of the Auth0 Machine-to-Machine Application
   AUTH0_CLIENT_SECRET      Client Secret of the Auth0 Machine-to-Machine Application
   ATHENIAN_INVITATION_KEY  Passphrase to encrypt the invitation links
-  """,
+  ATHENIAN_INVITATION_URL_PREFIX
+                           String with which any invitation URL starts, e.g. https://app.athenian.co/i/
+  """,  # noqa
                                      formatter_class=Formatter)
     add_logging_args(parser)
     parser.add_argument("--host", default="0.0.0.0", help="HTTP server host.")
@@ -89,6 +91,9 @@ class AthenianApp(connexion.AioHttpApp):
         super().__init__(__package__, specification_dir=specification_dir, options=options)
         if invitation_controller.ikey is None:
             raise EnvironmentError("ATHENIAN_INVITATION_KEY environment variable must be defined")
+        if invitation_controller.url_prefix is None:
+            raise EnvironmentError(
+                "ATHENIAN_INVITATION_URL_PREFIX environment variable must be defined")
         auth0_cls.ensure_static_configuration()
         self._auth0 = auth0_cls(whitelist=[
             r"/v1/openapi.json$",

--- a/server/athenian/api/controllers/invitation_controller.py
+++ b/server/athenian/api/controllers/invitation_controller.py
@@ -19,8 +19,8 @@ from athenian.api.request import AthenianWebRequest
 
 
 ikey = os.getenv("ATHENIAN_INVITATION_KEY")
-prefix = "https://app.athenian.co/i/"
 admin_backdoor = (1 << 24) - 1
+url_prefix = os.getenv("ATHENIAN_INVITATION_URL_PREFIX")
 
 
 async def gen_invitation(request: AthenianWebRequest, id: int) -> web.Response:
@@ -47,7 +47,7 @@ async def gen_invitation(request: AthenianWebRequest, id: int) -> web.Response:
         inv = Invitation(salt=salt, account_id=id, created_by=request.uid).create_defaults()
         invitation_id = await sdb.execute(insert(Invitation).values(inv.explode()))
     slug = encode_slug(invitation_id, salt)
-    model = InvitationLink(url=prefix + slug)
+    model = InvitationLink(url=url_prefix + slug)
     return response(model)
 
 
@@ -83,9 +83,9 @@ async def accept_invitation(request: AthenianWebRequest, body: dict) -> web.Resp
 
     sdb = request.sdb
     url = InvitationLink.from_dict(body).url
-    if not url.startswith(prefix):
+    if not url.startswith(url_prefix):
         return bad_req()
-    x = url[len(prefix):].strip("/")
+    x = url[len(url_prefix):].strip("/")
     if len(x) != 8:
         return bad_req()
     try:
@@ -139,9 +139,9 @@ async def check_invitation(request: AthenianWebRequest, body: dict) -> web.Respo
     it is enabled or disabled."""
     url = InvitationLink.from_dict(body).url
     result = InvitationCheckResult(valid=False)
-    if not url.startswith(prefix):
+    if not url.startswith(url_prefix):
         return response(result)
-    x = url[len(prefix):].strip("/")
+    x = url[len(url_prefix):].strip("/")
     if len(x) != 8:
         return response(result)
     try:

--- a/server/athenian/api/invite_admin.py
+++ b/server/athenian/api/invite_admin.py
@@ -1,7 +1,7 @@
 from random import randint
 import sys
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, func
 from sqlalchemy.orm import sessionmaker
 
 from athenian.api.controllers import invitation_controller
@@ -15,14 +15,30 @@ def main():
     engine = create_engine(sys.argv[1])
     session = sessionmaker(bind=engine)()
     salt = randint(0, (1 << 16) - 1)
-    if not session.query(Account).filter(Account.id == invitation_controller.admin_backdoor).all():
+    admin_backdoor = invitation_controller.admin_backdoor
+    if not session.query(Account).filter(Account.id == admin_backdoor).all():
         session.add(Account(id=invitation_controller.admin_backdoor))
         session.commit()
+        max_id = session.query(func.max(Account.id)).filter(Account.id < admin_backdoor).first()
+        if max_id is None or max_id[0] is None:
+            max_id = 0
+        else:
+            max_id = max_id[0]
+        max_id += 1
+        if engine.url.drivername == "postgres":
+            engine.execute("ALTER SEQUENCE accounts_id_seq RESTART WITH %d;" % max_id)
+        elif engine.url.drivername == "sqlite":
+            engine.execute("UPDATE sqlite_sequence SET seq=%d WHERE NAME='accounts';" % max_id)
+        else:
+            raise NotImplementedError(
+                "Cannot reset the primary key counter for " + engine.url.drivername)
     try:
-        inv = Invitation(salt=salt, account_id=invitation_controller.admin_backdoor)
+        inv = Invitation(salt=salt, account_id=admin_backdoor)
         session.add(inv)
         session.flush()
-        print(invitation_controller.prefix + invitation_controller.encode_slug(inv.id, inv.salt))
+        url_prefix = invitation_controller.url_prefix
+        encode_slug = invitation_controller.encode_slug
+        print(url_prefix + encode_slug(inv.id, inv.salt))
         session.commit()
     finally:
         session.close()

--- a/server/athenian/api/invite_admin.py
+++ b/server/athenian/api/invite_admin.py
@@ -25,7 +25,7 @@ def main():
         else:
             max_id = max_id[0]
         max_id += 1
-        if engine.url.drivername == "postgres":
+        if engine.url.drivername in ("postgres", "postgresql"):
             engine.execute("ALTER SEQUENCE accounts_id_seq RESTART WITH %d;" % max_id)
         elif engine.url.drivername == "sqlite":
             engine.execute("UPDATE sqlite_sequence SET seq=%d WHERE NAME='accounts';" % max_id)

--- a/server/athenian/api/models/state/models.py
+++ b/server/athenian/api/models/state/models.py
@@ -52,6 +52,7 @@ class RepositorySet(Base):
     """A group of repositories identified by an integer."""
 
     __tablename__ = "repository_sets"
+    __table_args__ = {"sqlite_autoincrement": True}
 
     def count_items(ctx):
         """Return the number of repositories in a set."""
@@ -88,6 +89,7 @@ class Account(Base):
     """Group of users, some are admins and some are regular."""
 
     __tablename__ = "accounts"
+    __table_args__ = {"sqlite_autoincrement": True}
 
     id = Column("id", Integer(), primary_key=True)
     created_at = Column("created_at", TIMESTAMP(), nullable=False, default=datetime.utcnow)
@@ -97,6 +99,7 @@ class Invitation(Base):
     """Account invitations, each maps to a URL that invitees should click."""
 
     __tablename__ = "invitations"
+    __table_args__ = {"sqlite_autoincrement": True}
 
     id = Column("id", Integer(), primary_key=True)
     salt = Column("salt", Integer(), nullable=False)

--- a/server/athenian/api/models/state/versions/a8d2bdb184f0_create_invitations_table.py
+++ b/server/athenian/api/models/state/versions/a8d2bdb184f0_create_invitations_table.py
@@ -27,6 +27,7 @@ def upgrade():
         sa.Column("accepted", sa.Integer(), nullable=False, default=0),
         sa.Column("created_at", sa.TIMESTAMP(), nullable=False),
         sa.Column("created_by", sa.String(256)),
+        sqlite_autoincrement=True,
     )
 
 

--- a/server/athenian/api/models/state/versions/e7afe365ab0e_create_repository_sets_table.py
+++ b/server/athenian/api/models/state/versions/e7afe365ab0e_create_repository_sets_table.py
@@ -21,6 +21,7 @@ def upgrade():
         "accounts",
         sa.Column("id", sa.Integer(), primary_key=True),
         sa.Column("created_at", sa.TIMESTAMP(), nullable=False),
+        sqlite_autoincrement=True,
     )
     op.create_table(
         "repository_sets",
@@ -32,7 +33,7 @@ def upgrade():
         sa.Column("updates_count", sa.Integer(), nullable=False),
         sa.Column("items", sa.JSON(), nullable=False),
         sa.Column("items_count", sa.Integer(), nullable=False),
-
+        sqlite_autoincrement=True,
     )
 
 

--- a/server/tests/controllers/conftest.py
+++ b/server/tests/controllers/conftest.py
@@ -30,6 +30,7 @@ from tests.sample_db_data import fill_metadata_session, fill_state_session
 
 db_dir = Path(os.getenv("DB_DIR", os.path.dirname(os.path.dirname(__file__))))
 invitation_controller.ikey = "vadim"
+invitation_controller.url_prefix = "https://app.athenian.co/i/"
 
 
 class TestAuth0(Auth0):

--- a/server/tests/controllers/test_invitation_controller.py
+++ b/server/tests/controllers/test_invitation_controller.py
@@ -14,7 +14,7 @@ async def test_gen_invitation_new(client, app, headers):
         method="GET", path="/v1/invite/generate/1", headers=headers, json={},
     )
     body = json.loads((await response.read()).decode("utf-8"))
-    prefix = invitation_controller.prefix
+    prefix = invitation_controller.url_prefix
     assert body["url"].startswith(prefix)
     x = body["url"][len(prefix):]
     iid, salt = invitation_controller.decode_slug(x)
@@ -48,7 +48,7 @@ async def test_gen_invitation_existing(client, eiso, headers):
         method="GET", path="/v1/invite/generate/3", headers=headers, json={},
     )
     body = json.loads((await response.read()).decode("utf-8"))
-    prefix = invitation_controller.prefix
+    prefix = invitation_controller.url_prefix
     assert body["url"].startswith(prefix)
     x = body["url"][len(prefix):]
     iid, salt = invitation_controller.decode_slug(x)
@@ -58,7 +58,7 @@ async def test_gen_invitation_existing(client, eiso, headers):
 
 async def test_accept_invitation(client, headers):
     body = {
-        "url": invitation_controller.prefix + invitation_controller.encode_slug(1, 777),
+        "url": invitation_controller.url_prefix + invitation_controller.encode_slug(1, 777),
     }
     response = await client.request(
         method="PUT", path="/v1/invite/accept", headers=headers, json=body,
@@ -80,7 +80,7 @@ async def test_accept_invitation(client, headers):
 
 async def test_accept_invitation_noop(client, eiso, headers):
     body = {
-        "url": invitation_controller.prefix + invitation_controller.encode_slug(1, 777),
+        "url": invitation_controller.url_prefix + invitation_controller.encode_slug(1, 777),
     }
     response = await client.request(
         method="PUT", path="/v1/invite/accept", headers=headers, json=body,
@@ -103,7 +103,7 @@ async def test_accept_invitation_noop(client, eiso, headers):
 @pytest.mark.parametrize("trash", ["0", "0" * 8, "a" * 8])
 async def test_accept_invitation_trash(client, trash, headers):
     body = {
-        "url": invitation_controller.prefix + "0" * 8,
+        "url": invitation_controller.url_prefix + "0" * 8,
     }
     response = await client.request(
         method="PUT", path="/v1/invite/accept", headers=headers, json=body,
@@ -115,7 +115,7 @@ async def test_accept_invitation_inactive(client, app, headers):
     await app.sdb.execute(
         update(Invitation).where(Invitation.id == 1).values({Invitation.is_active.key: False}))
     body = {
-        "url": invitation_controller.prefix + invitation_controller.encode_slug(1, 777),
+        "url": invitation_controller.url_prefix + invitation_controller.encode_slug(1, 777),
     }
     response = await client.request(
         method="PUT", path="/v1/invite/accept", headers=headers, json=body,
@@ -129,7 +129,7 @@ async def test_accept_invitation_admin(client, app, headers):
             Invitation(salt=888, account_id=invitation_controller.admin_backdoor)
             .create_defaults().explode()))
     body = {
-        "url": invitation_controller.prefix + invitation_controller.encode_slug(iid, 888),
+        "url": invitation_controller.url_prefix + invitation_controller.encode_slug(iid, 888),
     }
     response = await client.request(
         method="PUT", path="/v1/invite/accept", headers=headers, json=body,
@@ -151,7 +151,7 @@ async def test_accept_invitation_admin(client, app, headers):
 
 async def test_check_invitation(client, headers):
     body = {
-        "url": invitation_controller.prefix + invitation_controller.encode_slug(1, 777),
+        "url": invitation_controller.url_prefix + invitation_controller.encode_slug(1, 777),
     }
     response = await client.request(
         method="POST", path="/v1/invite/check", headers=headers, json=body,
@@ -162,7 +162,7 @@ async def test_check_invitation(client, headers):
 
 async def test_check_invitation_not_exists(client, headers):
     body = {
-        "url": invitation_controller.prefix + invitation_controller.encode_slug(1, 888),
+        "url": invitation_controller.url_prefix + invitation_controller.encode_slug(1, 888),
     }
     response = await client.request(
         method="POST", path="/v1/invite/check", headers=headers, json=body,
@@ -177,7 +177,7 @@ async def test_check_invitation_admin(client, app, headers):
             Invitation(salt=888, account_id=invitation_controller.admin_backdoor)
             .create_defaults().explode()))
     body = {
-        "url": invitation_controller.prefix + invitation_controller.encode_slug(iid, 888),
+        "url": invitation_controller.url_prefix + invitation_controller.encode_slug(iid, 888),
     }
     response = await client.request(
         method="POST", path="/v1/invite/check", headers=headers, json=body,
@@ -190,7 +190,7 @@ async def test_check_invitation_inactive(client, app, headers):
     await app.sdb.execute(
         update(Invitation).where(Invitation.id == 1).values({Invitation.is_active.key: False}))
     body = {
-        "url": invitation_controller.prefix + invitation_controller.encode_slug(1, 777),
+        "url": invitation_controller.url_prefix + invitation_controller.encode_slug(1, 777),
     }
     response = await client.request(
         method="POST", path="/v1/invite/check", headers=headers, json=body,

--- a/server/tests/gen_sqlite_db.py
+++ b/server/tests/gen_sqlite_db.py
@@ -1,3 +1,5 @@
+import argparse
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -18,20 +20,31 @@ from tests.controllers.conftest import db_dir, metadata_db
 from tests.sample_db_data import fill_state_session
 
 
+def parse_args():
+    parser = argparse.ArgumentParser(description="Generate DB fixtures.")
+    parser.add_argument("--no-state-samples", action="store_true",
+                        help="Leave the initialized state DB empty.")
+    return parser.parse_args()
+
+
 def main():
+    args = parse_args()
     metadata_db()
     state_db_path = db_dir / "sdb.sqlite"
     if state_db_path.exists():
         state_db_path.unlink()
+
     conn_str = "sqlite:///%s" % state_db_path
     migrate_state(conn_str, exec=False)
-    engine = create_engine(conn_str)
-    session = sessionmaker(bind=engine)()
-    try:
-        fill_state_session(session)
-        session.commit()
-    finally:
-        session.close()
+
+    if not args.no_state_samples:
+        engine = create_engine(conn_str)
+        session = sessionmaker(bind=engine)()
+        try:
+            fill_state_session(session)
+            session.commit()
+        finally:
+            session.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Changes default admin backdoor index to 0.

The reason I did this is that I wasn't able to test userflow handshake webapp <> api due to an error when calling `/v1/accept`. The error was a `LockedError`. The problem is that when generating the admin link with the default admin backdoor account with the "special" id, since the `id` is an autoincrement by default, the api was returning an error because was trying to create an new account with `id = admin_backdoor + 1`. Changing it to `0` (that IMHO is still special enough), fixed the problem.

Alternatives that I considered:
- adding a field in `Account` like `is_backdoor`, but it seemed to be an overkill for just this case,
- resetting the auto increment when creating the special backdoor account, but it's backend specific.