### PR TITLE
Fix function signature from UserAccount

### DIFF
--- a/server/athenian/api/create_default_user.py
+++ b/server/athenian/api/create_default_user.py
@@ -16,7 +16,11 @@ def main():
     acc = Account()
     session.add(acc)
     session.flush()
-    session.add(UserAccount(Auth0.DEFAULT_USER, acc.id, False))
+    session.add(UserAccount(
+        user_id=Auth0.DEFAULT_USER,
+        account_id=acc.id,
+        is_admin=False,
+    ))
     session.add(RepositorySet(owner=acc.id, items=[
         "github.com/athenianco/athenian-api",
         "github.com/athenianco/metadata",

--- a/server/athenian/api/metadata.py
+++ b/server/athenian/api/metadata.py
@@ -1,3 +1,3 @@
 __package__ = "athenian.api"
-__version__ = "0.0.4"
+__version__ = "0.0.5"
 __description__ = "Athenian Owl API"


### PR DESCRIPTION
This fix this issue

```bash
$ make gkwillie 
docker run --rm -e DB_DIR=/io -v/data/src/athenian/athenian-api/server/tests:/io --env-file .env --entrypoint python3 athenian/api:dev -m athenian.api.create_default_user sqlite:///io/sdb.sqlite
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/server/athenian/api/create_default_user.py", line 30, in <module>
    exit(main())
  File "/server/athenian/api/create_default_user.py", line 19, in main
    session.add(UserAccount(Auth0.DEFAULT_USER, acc.id, False))
TypeError: __init__() takes 1 positional argument but 4 were given
make: *** [Makefile:44: gkwillie] Error 1
```