### PR TITLE
Revert "Categorize the endpoints"

### DIFF
--- a/server/athenian/api/openapi/openapi.yaml
+++ b/server/athenian/api/openapi/openapi.yaml
@@ -45,8 +45,6 @@ paths:
           description: The account was not found.
       security:
       - bearerAuth: []
-      tags:
-      - user
       summary: List the current user's account members.
       x-openapi-router-controller: athenian.api.controllers.user_controller
       x-codegen-request-body-name: body
@@ -83,8 +81,6 @@ paths:
           description: Requested user does not exist.
       security:
       - bearerAuth: []
-      tags:
-      - user
       summary: \"God mode\" ability to turn into any user. The current user must be
         marked internally as a super admin.
       x-openapi-router-controller: athenian.api.controllers.user_controller
@@ -113,8 +109,6 @@ paths:
           description: Current user is not allowed to access the specified account.
       security:
       - bearerAuth: []
-      tags:
-      - filter
       summary: Find developers that made an action within the given timeframe.
       x-openapi-router-controller: athenian.api.controllers.filter_controller
       x-codegen-request-body-name: body
@@ -143,8 +137,6 @@ paths:
             or reposets.
       security:
       - bearerAuth: []
-      tags:
-      - filter
       summary: List pull requests that satisfy the query.
       x-openapi-router-controller: athenian.api.controllers.filter_controller
   /filter/repositories:
@@ -172,8 +164,6 @@ paths:
             or reposets.
       security:
       - bearerAuth: []
-      tags:
-      - filter
       summary: Find repositories that were updated within the given timeframe.
       x-openapi-router-controller: athenian.api.controllers.filter_controller
       x-codegen-request-body-name: body
@@ -215,8 +205,6 @@ paths:
           description: Invitation was not found.
       security:
       - bearerAuth: []
-      tags:
-      - registration
       summary: Accept the account membership invitation and finish registration. The
         user must be already authorized in Auth0.
       x-openapi-router-controller: athenian.api.controllers.invitation_controller
@@ -242,8 +230,6 @@ paths:
             it is correctly formed and is enabled.'
       summary: Given an invitation URL, get its type (admin or regular account member)
         and find whether it is correctly formed and is enabled or disabled.
-      tags:
-      - registration
       x-openapi-router-controller: athenian.api.controllers.invitation_controller
       x-codegen-request-body-name: body
   /invite/generate/{id}:
@@ -279,8 +265,6 @@ paths:
           description: The account was not found.
       security:
       - bearerAuth: []
-      tags:
-      - registration
       summary: Generate an account invitation link for regular users. The caller must
         be an admin of the specified account.
       x-openapi-router-controller: athenian.api.controllers.invitation_controller
@@ -324,8 +308,6 @@ paths:
           description: No data is available to calculate metrics for the given repositories.
       security:
       - bearerAuth: []
-      tags:
-      - metrics
       summary: Calculate metrics.
       x-openapi-router-controller: athenian.api.controllers.metrics_controller
       x-codegen-request-body-name: body
@@ -354,8 +336,6 @@ paths:
             items.
       security:
       - bearerAuth: []
-      tags:
-      - reposet
       summary: Create a repository set.
       x-openapi-router-controller: athenian.api.controllers.reposet_controller
       x-codegen-request-body-name: body
@@ -392,8 +372,6 @@ paths:
           description: The specified repository set was not found.
       security:
       - bearerAuth: []
-      tags:
-      - reposet
       summary: Delete a repository set. The user must be an admin of the account that
         owns the reposet.
       x-openapi-router-controller: athenian.api.controllers.reposet_controller
@@ -430,8 +408,6 @@ paths:
           description: The specified repository set was not found.
       security:
       - bearerAuth: []
-      tags:
-      - reposet
       summary: List a repository set. The user must be in the account that owns the
         reposet.
       x-openapi-router-controller: athenian.api.controllers.reposet_controller
@@ -474,8 +450,6 @@ paths:
           description: The specified repository set was not found.
       security:
       - bearerAuth: []
-      tags:
-      - reposet
       summary: Update a repository set. The user must be an admin of the account that
         owns the reposet.
       x-openapi-router-controller: athenian.api.controllers.reposet_controller
@@ -507,8 +481,6 @@ paths:
           description: The user does not belong to the specified account.
       security:
       - bearerAuth: []
-      tags:
-      - reposet
       summary: List the repository sets belonging to the current user.
       x-openapi-router-controller: athenian.api.controllers.reposet_controller
       x-codegen-request-body-name: body
@@ -524,8 +496,6 @@ paths:
           description: Details about the current user.
       security:
       - bearerAuth: []
-      tags:
-      - user
       summary: Show details about the current user.
       x-openapi-router-controller: athenian.api.controllers.user_controller
       x-codegen-request-body-name: body


### PR DESCRIPTION
This reverts commit 478d41ce335f16d63873374444ca33e3b936e40f.

I'm not sure about the purpose of the endpoint categorization, but if it was mostly cosmetics, and it can be reverted without breaking the API, please revert it because it's changing the autogenerated API client in a way that `webapp` can not handle.

We can restore the categorization after release 1.