### PR TITLE
Test JS API Client autogeneration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,13 @@ matrix:
         - set +e
     - if: commit_message !~ /Bump version/
       stage: main
+      name: Auto generated js client tests
+      script:
+        - docker run --rm -v `pwd`:/local --user `id -u`:`id -g` openapitools/openapi-generator-cli generate --input-spec=/local/spec/openapi.yaml --generator-name=javascript --output=/local/js-client
+        - npm --prefix js-client install
+        - npm --prefix js-client test
+    - if: commit_message !~ /Bump version/
+      stage: main
       name: Docker build smoke test
       before_install:
         - docker load -i $HOME/docker/images.tar || true


### PR DESCRIPTION
This PR will introduce into Travis build a test to ensure that the autogenerated JS API client won't fail, which can happen as demoed by https://github.com/dpordomingo/athenian-api/pull/4; if that case happens, it will be raised a red flag in Travis [like this one](https://travis-ci.com/dpordomingo/athenian-api/jobs/293797859#L488).