### PR TITLE
Fix imports in setup.py

### DIFF
--- a/server/setup.py
+++ b/server/setup.py
@@ -1,8 +1,11 @@
 from importlib.machinery import SourceFileLoader
 import os
 
-from Cython.Build import cythonize
 from setuptools import find_packages, setup
+# The following import has to stay after imports from `setuptools`:
+# - https://stackoverflow.com/questions/21594925/
+#     error-each-element-of-ext-modules-option-must-be-an-extension-instance-or-2-t
+from Cython.Build import cythonize  # noqa: I100
 
 version = SourceFileLoader("version", "athenian/api/metadata.py").load_module()
 


### PR DESCRIPTION
I wasn't able to build the cython extension without this imports ordering. See: https://stackoverflow.com/questions/21594925/error-each-element-of-ext-modules-option-must-be-an-extension-instance-or-2-t

I built it by running:
```
python setup.py build_ext --inplace
```

as explained [here](http://docs.cython.org/en/latest/src/quickstart/build.html#building-a-cython-module-using-setuptools).