### PR TITLE
Running api with dump of real data

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,54 @@
+version: "3.7"
+services:
+  api:
+    image: ${API_IMAGE:-gcr.io/athenian-1/api:latest}
+    restart: unless-stopped
+    entrypoint: ['/bin/sh']
+    command: >
+      -c "python3 -m athenian.api.models.state \
+            postgresql://${POSTGRES_USER:-api}:${POSTGRES_PASSWORD:-api}@postgres:5432/state &&
+          python3 -m athenian.api \
+            --log-level=${API_LOG_LEVEL:-INFO} \
+            --log-structured \
+            --host=0.0.0.0 \
+            --port=8080 \
+            --metadata-db=postgresql://${POSTGRES_USER:-api}:${POSTGRES_PASSWORD:-api}@postgres:5432/metadata \
+            --state-db=postgresql://${POSTGRES_USER:-api}:${POSTGRES_PASSWORD:-api}@postgres:5432/state \
+            --precomputed-db=postgresql://${POSTGRES_USER:-api}:${POSTGRES_PASSWORD:-api}@postgres:5432/precomputed \
+            --ui"
+    env_file: .env
+    ports:
+      - ${API_HOST_PORT:-8080}:8080
+    depends_on:
+      - postgres
+      - memcached
+
+  postgres:
+    image: postgres:9.6-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-api}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-api}
+    volumes:
+      - postgres:/var/lib/postgresql/data
+      - db_dumps:/db_dumps
+
+  memcached:
+    image: launcher.gcr.io/google/memcached1
+    command: ['memcached', '-m', '64']
+
+  cloud_sql_proxy:
+    image: gcr.io/cloudsql-docker/gce-proxy:1.14
+    command: [
+      '/cloud_sql_proxy',
+      '-instances=${CLOUD_SQL_STAGING_INSTANCE}=tcp:0.0.0.0:5432,${CLOUD_SQL_PRODUCTION_INSTANCE}=tcp:0.0.0.0:5433',
+      '-credential_file=/secrets/cloudsql/credentials.json'
+    ]
+    volumes:
+      - ${CLOUD_SQL_PROXY_CREDENTIALS_FILE:-./credentials.json}:/secrets/cloudsql/credentials.json
+
+volumes:
+  postgres:
+    external: false
+  db_dumps:
+    external: false

--- a/server/README.md
+++ b/server/README.md
@@ -95,7 +95,7 @@ Generate sample SQLite metadata and state databases:
 
 ```
 docker run --rm -e DB_DIR=/io -v$(pwd):/io --entrypoint python3 athenian/api /server/tests/gen_sqlite_db.py
-``` 
+```
 
 You should have two SQLite files in `$(pwd)`: `mdb.sqlite` and `sdb.sqlite`. The third DB `--precomputed-db` can be set to any (already existing or not) `.sqlite` file or `sqlite://`.
 
@@ -141,6 +141,67 @@ You can erase the API data fixtures created by `make run-api` with:
 ```
 make clean
 ```
+
+## Running the API server locally with real data
+
+You can also run the api server and all the other services with real data using docker compose. For this setup you'll need the following:
+- docker compose,
+- an `.env` file setup with also all the credentials for Auth0,
+- gloud locally setup and authenticated with Athenian's email,
+- a Google Cloud service account with the corresponding json credentials file to connect to the CloudSQL database,
+- the credentials for the CloudSQL databases and the name of the instances.
+
+Spin up the container with postgres and the container with cloud sql proxy:
+```
+$ CLOUD_SQL_STAGING_INSTANCE=<instance name> CLOUD_SQL_PRODUCTION_INSTANCE=<instance name> docker-compose up cloud_sql_proxy postgres
+```
+
+This step requires the credentials of the service account in a json file. The default path is `./credentials.json`, otherwise it can be set using the `CLOUD_SQL_PROXY_CREDENTIALS_FILE` env var.
+
+Once the database is ready to accept connections, run `server/tests/load_postgres_data.py`. This script accepts a single argument that is the environment name. The accepted values are: `staging` and `production`:
+```
+$ python3 server/tests/load_postgres_data.py staging --remote-postgres-user=<name of the pg user>
+```
+
+This will ask to input the password for the CloudSQL instance as follows:
+```
+Password for CloudSQL instance of 'staging' environment of user '<pg user>':
+```
+
+Then it will dump `state`, `precomputed` and `metadata` databases from the live environment and restores it into the `postgres` container. Here's an example log:
+```
+Password for CloudSQL instance of 'staging' environment of user '<pg user>:
+Dumping database: pg_dump --host cloud_sql_proxy --port 5432 --username=<pg user> -Fc --dbname=state > /db_dumps/state.dump
+Done!
+Creating database: createdb -U api state
+Loading dump into container: pg_restore -x -Fc -O -U api -d state /db_dumps/state.dump
+Done!
+Dumping database: pg_dump --host cloud_sql_proxy --port 5432 --username=<pg user> -Fc --dbname=precomputed > /db_dumps/precomputed.dump
+Done!
+Creating database: createdb -U api precomputed
+Loading dump into container: pg_restore -x -Fc -O -U api -d precomputed /db_dumps/precomputed.dump
+Done!
+Dumping database: pg_dump --host cloud_sql_proxy --port 5432 --username=<pg user> -Fc --dbname=metadata > /db_dumps/metadata.dump
+Done!
+Creating database: createdb -U api metadata
+Loading dump into container: pg_restore -x -Fc -O -U api -d metadata /db_dumps/metadata.dump
+pg_restore: WARNING:  column "labels" has type "unknown"
+DETAIL:  Proceeding with relation creation anyway.
+pg_restore: WARNING:  column "milestone_id" has type "unknown"
+DETAIL:  Proceeding with relation creation anyway.
+pg_restore: WARNING:  column "milestone_title" has type "unknown"
+DETAIL:  Proceeding with relation creation anyway.
+Done!
+```
+
+Now you can finally run the `api`:
+```
+$ docker-compose up api
+```
+
+By default it runs the latest image, that is `gcr.io/athenian-1/api:latest`. It can be changed using the `API_IMAGE` env var.
+
+This will also spin up `memcached`. The api is now ready with real data at port `8080`. The port can otherwise be customized using the `API_HOST_PORT` env var.
 
 ## @gkwillie
 

--- a/server/tests/load_postgres_data.py
+++ b/server/tests/load_postgres_data.py
@@ -1,0 +1,92 @@
+import argparse
+import getpass
+import os
+import subprocess
+import sys
+
+conf = {
+    "staging": {
+        "port": 5432,
+    },
+    "production": {
+        "port": 5433,
+    },
+}
+
+
+def run_pg_cmd_on_guest(guest_cmd, password):
+    """Run a postgres command in the guest container."""
+    return subprocess.run([
+        "docker-compose exec -e PGPASSWORD=%s postgres bash -c '%s'" % (
+            password, guest_cmd),
+    ], shell=True, check=True)
+
+
+def parse_args():
+    """Parse arguments for the posgres data loader command."""
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("environment", default="staging", choices=conf,
+                        help="Name of the environment the data will be taken from")
+    parser.add_argument("--remote-postgres-user",
+                        default=os.environ.get("CLOUD_SQL_POSTGRES_USER"),
+                        help="Name of the user to use for the local db")
+    parser.add_argument("--local-postgres-user",
+                        default=os.environ.get("POSTGRES_USER", "api"),
+                        help="Name of the user to use for the local db")
+
+    parsed_args = parser.parse_args()
+
+    if not parsed_args.remote_postgres_user:
+        raise ValueError("Missing remote postgres user")
+
+    if not parsed_args.local_postgres_user:
+        raise ValueError("Missing local postgres user")
+
+    return parsed_args
+
+
+def main():
+    """Run the postgres data loader."""
+    try:
+        args = parse_args()
+    except ValueError as e:
+        print(e, file=sys.stderr)
+        return 1
+
+    dbs = ["state", "precomputed", "metadata"]
+    remote_postgres_password = getpass.getpass(
+        prompt=("Password for CloudSQL instance of '%s' environment "
+                "of user '%s': " % (
+                    args.environment, args.remote_postgres_user)))
+
+    config = conf[args.environment]
+    dumps_base_path = "/db_dumps"
+    for db in dbs:
+        file_name = "%s.dump" % db
+        dump_path = os.path.join(dumps_base_path, file_name)
+
+        guest_cmd = (
+            "pg_dump --host cloud_sql_proxy --port=%d --username=%s "
+            "-Fc --dbname=%s > %s"
+        ) % (config["port"], args.remote_postgres_user, db, dump_path)
+
+        print("Dumping database: %s" % guest_cmd)
+        run_pg_cmd_on_guest(guest_cmd, remote_postgres_password)
+        print("Done!")
+
+        guest_cmd = "createdb -U %s %s" % (args.local_postgres_user, db)
+        print("Creating database: %s" % guest_cmd)
+        run_pg_cmd_on_guest(guest_cmd, remote_postgres_password)
+
+        guest_cmd = "pg_restore -x -Fc -O -U %s -d %s %s" % (
+            args.local_postgres_user, db, dump_path)
+        print("Loading dump into container: %s" % guest_cmd)
+        run_pg_cmd_on_guest(guest_cmd, remote_postgres_password)
+        print("Done!")
+
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())


### PR DESCRIPTION
Closes [ENG-389](https://athenianco.atlassian.net/browse/ENG-389).

This PR aims to provide an easy way to run the api with a dump of the real data (`staging` or `production`). This is done with docker compose with 4 containers:
- api
- Memcached (for caching)
- postgres (for `state`, `precomputed` and `metadata` dabases)
- cloud SQL proxy (for connecting to the live environment and dump the databases)

The requirements are:
- docker compose,
- a service account with the corresponding json credentials file to connect to the CloudSQL database,
- the credentials for the CloudSQL databases.

See [here](https://github.com/athenianco/athenian-api/compare/local-development?expand=1#diff-7d62b4cde47a08800e3b7212ca2dd397R145) for more details.

## Video example

https://streamable.com/fu7abs

## Notes

Running the api in the container seems much more slower, at least on OSX, but I didn't investigate. Also, api can still be run locally natively and use only the services offered by docker compose.