### PR TITLE
Implement `/contributors/{id}` endpoint

### DIFF
--- a/server/athenian/api/controllers/contributors_controller.py
+++ b/server/athenian/api/controllers/contributors_controller.py
@@ -2,7 +2,7 @@ from aiohttp import web
 from sqlalchemy import and_, select
 
 from athenian.api.controllers.miners.access_classes import access_classes
-from athenian.api.controllers.miners.github.contributors import mine_all_contributors
+from athenian.api.controllers.miners.github.contributors import mine_contributors
 from athenian.api.models.state.models import UserAccount
 from athenian.api.models.web import Contributor, NotFoundError
 from athenian.api.response import FriendlyJson, ResponseError
@@ -31,7 +31,8 @@ async def get_contributors(request: web.Request, id: int) -> web.Response:
             return e.response
 
         repos = checker.installed_repos(with_prefix=False)
-        users = await mine_all_contributors(repos, request.mdb, request.cache)
+        users = await mine_contributors(repos, request.mdb, with_stats=False,
+                                        cache=request.cache)
 
         contributors = [
             Contributor(login=f"github.com/{u['login']}", name=u["name"],

--- a/server/athenian/api/controllers/contributors_controller.py
+++ b/server/athenian/api/controllers/contributors_controller.py
@@ -1,4 +1,11 @@
 from aiohttp import web
+from sqlalchemy import and_, select
+
+from athenian.api.controllers.miners.access_classes import access_classes
+from athenian.api.controllers.miners.github.contributors import mine_all_contributors
+from athenian.api.models.state.models import UserAccount
+from athenian.api.models.web import Contributor, NotFoundError
+from athenian.api.response import FriendlyJson, ResponseError
 
 
 async def get_contributors(request: web.Request, id: int) -> web.Response:
@@ -7,4 +14,29 @@ async def get_contributors(request: web.Request, id: int) -> web.Response:
     :param id: Numeric identifier of the account.
 
     """
-    return web.Response(status=200)
+    user = await request.user()
+
+    async with request.sdb.connection() as sdb_conn:
+        account_id = await sdb_conn.fetch_val(
+            select([UserAccount.account_id])
+            .where(and_(UserAccount.user_id == user.id, UserAccount.account_id == id)))
+        if account_id is None:
+            err_detail = f"Account {account_id} does not exist or user {user} is not a member."
+            return ResponseError(NotFoundError(detail=err_detail)).response
+
+        try:
+            checker = await access_classes["github"](
+                account_id, sdb_conn, request.mdb, request.cache).load()
+        except ResponseError as e:
+            return e.response
+
+        repos = checker.installed_repos(with_prefix=False)
+        users = await mine_all_contributors(repos, request.mdb, request.cache)
+
+        contributors = [
+            Contributor(login=f"github.com/{u['login']}", name=u["name"],
+                        email=u["email"], picture=u["avatar_url"]).to_dict()
+            for u in users
+        ]
+
+        return web.json_response(contributors, dumps=FriendlyJson.dumps)

--- a/server/athenian/api/controllers/contributors_controller.py
+++ b/server/athenian/api/controllers/contributors_controller.py
@@ -14,14 +14,15 @@ async def get_contributors(request: web.Request, id: int) -> web.Response:
     :param id: Numeric identifier of the account.
 
     """
-    user = await request.user()
-
     async with request.sdb.connection() as sdb_conn:
         account_id = await sdb_conn.fetch_val(
             select([UserAccount.account_id])
-            .where(and_(UserAccount.user_id == user.id, UserAccount.account_id == id)))
+            .where(and_(UserAccount.user_id == request.uid, UserAccount.account_id == id)))
         if account_id is None:
-            err_detail = f"Account {account_id} does not exist or user {user} is not a member."
+            err_detail = (
+                f"Account {account_id} does not exist or user {request.uid} "
+                "is not a member."
+            )
             return ResponseError(NotFoundError(detail=err_detail)).response
 
         try:

--- a/server/athenian/api/controllers/miners/access.py
+++ b/server/athenian/api/controllers/miners/access.py
@@ -2,6 +2,7 @@ from typing import Optional, Set
 
 import aiomcache
 
+from athenian.api.models.metadata import PREFIXES
 from athenian.api.typing_utils import DatabaseLike
 
 
@@ -9,6 +10,7 @@ class AccessChecker:
     """Interface for all repository access checkers."""
 
     CACHE_TTL = 60 * 60  # 1 hour
+    SERVICE = ""
 
     def __init__(self,
                  account: int,
@@ -28,9 +30,10 @@ class AccessChecker:
         self.cache_ttl = cache_ttl
         self._installed_repos = set()
 
-    def installed_repos(self) -> Set[str]:
-        """Get the currently installed repository names *with* the service prefix."""
-        raise NotImplementedError
+    def installed_repos(self, with_prefix: bool = True) -> Set[str]:
+        """Get the currently installed repository names."""
+        prefix = PREFIXES[self.SERVICE] if with_prefix else ""
+        return {f"{prefix}{r}" for r in self._installed_repos}
 
     async def load(self) -> "AccessChecker":
         """Fetch the list of accessible repositories."""

--- a/server/athenian/api/controllers/miners/github/access.py
+++ b/server/athenian/api/controllers/miners/github/access.py
@@ -17,6 +17,8 @@ class GitHubAccessChecker(AccessChecker):
     the checked set.
     """
 
+    SERVICE = "github"
+
     async def load(self) -> "AccessChecker":
         """Fetch the list of accessible repositories."""
         iids = await get_installation_ids(self.account, self.sdb, self.cache)
@@ -36,10 +38,6 @@ class GitHubAccessChecker(AccessChecker):
             .where(InstallationRepo.install_id.in_(iids)))
         key = InstallationRepo.repo_full_name.key
         return {r[key] for r in installed_repos_db}
-
-    def installed_repos(self) -> Set[str]:
-        """Get the currently installed repository names *with* the service prefix."""
-        return {"github.com/" + r for r in self._installed_repos}
 
     async def check(self, repos: Set[str]) -> Set[str]:
         """Return repositories which do not belong to the metadata installation.

--- a/server/athenian/api/openapi/openapi.yaml
+++ b/server/athenian/api/openapi/openapi.yaml
@@ -1082,24 +1082,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Contributors'
           description: List of all contributors belonging to the specified account.
-        403:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GenericError'
-          description: The user is forbidden to list contributors belonging to the specified account.
         404:
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: The user does not belong to the specified account.
-        409:
+        422:
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
-          description: Concurrent requests that are finishing the account registration.
+          description: The installation has not started yet.
       security:
       - bearerAuth: []
       summary: List all the contributors belonging to the specified account.

--- a/server/tests/controllers/miners/github/test_contributors.py
+++ b/server/tests/controllers/miners/github/test_contributors.py
@@ -1,0 +1,28 @@
+from operator import itemgetter
+
+import pytest
+
+from athenian.api.controllers.miners.github.contributors import mine_contributors
+from tests.conftest import has_memcached
+
+
+async def test_mine_contributors_expected_cache_miss(mdb, cache, memcached):
+    if not has_memcached:
+        raise pytest.skip("no memcached")
+    cache = memcached
+
+    contribs_with_stats = await mine_contributors(["src-d/go-git"], mdb, cache=cache)
+    contribs_with_no_stats = await mine_contributors(["src-d/go-git"], mdb, with_stats=False,
+                                                     cache=cache)
+
+    assert len(contribs_with_stats) == len(contribs_with_no_stats)
+
+    for c_with_stats, c_no_stats in zip(
+            sorted(contribs_with_stats, key=itemgetter("login")),
+            sorted(contribs_with_no_stats, key=itemgetter("login"))):
+        assert "stats" in c_with_stats
+        assert "stats" not in c_no_stats
+
+        c_with_stats.pop("stats")
+
+        assert c_with_stats == c_no_stats

--- a/server/tests/controllers/test_contributors_controller.py
+++ b/server/tests/controllers/test_contributors_controller.py
@@ -1,0 +1,75 @@
+import json
+
+import pytest
+
+
+@pytest.mark.parametrize("cached", [False, True], ids=["no cache", "with cache"])
+async def test_get_contributors_as_admin(client, cached, headers, app, cache):
+    await _test_get_contributors(client, cached, headers, app, cache)
+
+
+@pytest.mark.parametrize("cached", [False, True], ids=["no cache", "with cache"])
+async def test_get_contributors_as_non_admin(client, cached, headers, app, cache, eiso):
+    await _test_get_contributors(client, cached, headers, app, cache)
+
+
+async def _test_get_contributors(client, cached, headers, app, cache):
+    if cached:
+        app._cache = cache
+
+    response = await client.request(
+        method="GET", path="/v1/contributors/1", headers=headers,
+    )
+
+    assert response.status == 200
+
+    contribs = json.loads((await response.read()).decode("utf-8"))
+
+    assert len(contribs) == 206
+    assert len(set(c["login"] for c in contribs)) == len(contribs)
+    assert all(c["login"].startswith("github.com/") for c in contribs)
+
+    contribs = {c["login"]: c for c in contribs}
+    assert "github.com/mcuadros" in contribs
+    assert "github.com/author_login" not in contribs
+    assert "github.com/committer_login" not in contribs
+    assert contribs["github.com/mcuadros"]["picture"]
+    assert contribs["github.com/mcuadros"]["name"] == "Máximo Cuadros"
+
+
+async def test_get_contributors_no_installation(client, headers):
+    response = await client.request(
+        method="GET", path="/v1/contributors/2", headers=headers,
+    )
+
+    assert response.status == 422
+
+    parsed = json.loads((await response.read()).decode("utf-8"))
+
+    assert parsed == {
+        "type": "/errors/NoSourceDataError",
+        "title": "Unprocessable Entity",
+        "status": 422,
+        "detail": "The account installation has not finished yet.",
+    }
+
+
+@pytest.mark.parametrize("account", [3, 4],
+                         ids=["user is not a member of account",
+                              "account doesn't exist"])
+async def test_get_contributors_not_found(client, account, headers):
+    response = await client.request(
+        method="GET", path="/v1/contributors/3", headers=headers,
+    )
+
+    assert response.status == 404
+
+    parsed = json.loads((await response.read()).decode("utf-8"))
+    err_detail = parsed.pop("detail")
+
+    assert err_detail.startswith("Account None does not exist or user")
+    assert parsed == {
+        "status": 404,
+        "title": "Not Found",
+        "type": "/errors/NotFoundError",
+    }

--- a/server/tests/controllers/test_contributors_controller.py
+++ b/server/tests/controllers/test_contributors_controller.py
@@ -2,6 +2,8 @@ import json
 
 import pytest
 
+from athenian.api.models.web import Contributor
+
 
 @pytest.mark.parametrize("cached", [False, True], ids=["no cache", "with cache"])
 async def test_get_contributors_as_admin(client, cached, headers, app, cache):
@@ -23,18 +25,19 @@ async def _test_get_contributors(client, cached, headers, app, cache):
 
     assert response.status == 200
 
-    contribs = json.loads((await response.read()).decode("utf-8"))
+    contribs = [Contributor.from_dict(c) for c in json.loads(
+        (await response.read()).decode("utf-8"))]
 
     assert len(contribs) == 206
-    assert len(set(c["login"] for c in contribs)) == len(contribs)
-    assert all(c["login"].startswith("github.com/") for c in contribs)
+    assert len(set(c.login for c in contribs)) == len(contribs)
+    assert all(c.login.startswith("github.com/") for c in contribs)
 
-    contribs = {c["login"]: c for c in contribs}
+    contribs = {c.login: c for c in contribs}
     assert "github.com/mcuadros" in contribs
     assert "github.com/author_login" not in contribs
     assert "github.com/committer_login" not in contribs
-    assert contribs["github.com/mcuadros"]["picture"]
-    assert contribs["github.com/mcuadros"]["name"] == "Máximo Cuadros"
+    assert contribs["github.com/mcuadros"].picture
+    assert contribs["github.com/mcuadros"].name == "Máximo Cuadros"
 
 
 async def test_get_contributors_no_installation(client, headers):

--- a/server/tests/controllers/test_contributors_controller.py
+++ b/server/tests/controllers/test_contributors_controller.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from athenian.api.models.web import Contributor
+from tests.conftest import has_memcached
 
 
 @pytest.mark.parametrize("cached", [False, True], ids=["no cache", "with cache"])
@@ -17,6 +18,8 @@ async def test_get_contributors_as_non_admin(client, cached, headers, app, cache
 
 async def _test_get_contributors(client, cached, headers, app, cache):
     if cached:
+        if not has_memcached:
+            raise pytest.skip("no memcached")
         app._cache = cache
 
     response = await client.request(


### PR DESCRIPTION
This implements the `/contributors/{id}` endpoint and updates the spec file with the actual errors that could be returned.