### PR TITLE
Define default JIRA_INSTALLATION_URL tpl in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,8 @@ services:
             --precomputed-db=postgresql://${POSTGRES_USER:-api}:${POSTGRES_PASSWORD:-api}@postgres:5432/precomputed \
             --ui"
     env_file: .env
+    environment:
+      - ATHENIAN_JIRA_INSTALLATION_URL_TEMPLATE=${ATHENIAN_JIRA_INSTALLATION_URL_TEMPLATE:-https://installation.athenian.co/jira/%s/atlassian-connect.json}
     ports:
       - ${API_HOST_PORT:-8080}:8080
     depends_on:


### PR DESCRIPTION
Define default `ATHENIAN_JIRA_INSTALLATION_URL_TEMPLATE` in docker-compose

It will be used also in pre-staging envs.
If the user already uses a `.env` file, it will be used instead of this default

## TL;DR

I locally tested it this way:
```
$ docker-compose up
$ docker-compose exec -T api /bin/bash
echo $ATHENIAN_JIRA_INSTALLATION_URL_TEMPLATE
```
The value from local `.env` is kept.
The value from `docker-compose.yml::environment` is only used if the variable is not in the local `.env`