### PR TITLE
Define default sentry conf in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,6 +23,9 @@ services:
             --ui"
     env_file: .env
     environment:
+      - SENTRY_PROJECT=${SENTRY_PROJECT:-1867351}
+      - SENTRY_KEY=${SENTRY_KEY:-9d68b3ad311f4337904f225e189ffea1}
+      - ATHENIAN_DEV_ID=${ATHENIAN_DEV_ID:-pre-staging}
       - ATHENIAN_JIRA_INSTALLATION_URL_TEMPLATE=${ATHENIAN_JIRA_INSTALLATION_URL_TEMPLATE:-https://installation.athenian.co/jira/%s/atlassian-connect.json}
     ports:
       - ${API_HOST_PORT:-8080}:8080

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,8 @@ services:
             --precomputed-db=postgresql://${POSTGRES_USER:-api}:${POSTGRES_PASSWORD:-api}@postgres:5432/precomputed \
             --ui"
     env_file: .env
+    environment:
+      - ATHENIAN_JIRA_INSTALLATION_URL_TEMPLATE=${ATHENIAN_JIRA_INSTALLATION_URL_TEMPLATE:-https://installation.athenian.co/jira/%s/atlassian-connect.json}
     ports:
       - ${API_HOST_PORT:-8080}:8080
     depends_on:


### PR DESCRIPTION
depends on https://github.com/athenianco/athenian-api/pull/495

Define default sentry conf in `docker-compose`.

I will be used also in pre-staging envs, so errors will be sent to sent to Sentry (development environment)
If the user already uses a `.env` file, it will be used instead of this default

### TODO
- create another distinct `pre-staging` Sentry environment.

## TL;DR

I locally tested it this way:
```
$ docker-compose up
$ docker-compose exec -T api /bin/bash
echo $SENTRY_PROJECT
```
The value from local `.env` is kept.
The value from `docker-compose.yml::environment` is only used if the variable is not in the local `.env`