### PR TITLE
[DEV-1206] Add the Team's parent to the spec

### DIFF
--- a/server/athenian/api/models/web/team.py
+++ b/server/athenian/api/models/web/team.py
@@ -5,26 +5,39 @@ from athenian.api.models.web.contributor import Contributor
 
 
 class Team(Model):
-    """List of team members."""
+    """Definition of a team of several developers."""
 
-    openapi_types = {"id": int, "name": str, "members": List[Contributor]}
-    attribute_map = {"id": "id", "name": "name", "members": "members"}
+    openapi_types = {
+        "id": int,
+        "name": str,
+        "members": List[Contributor],
+        "parent": int,
+    }
+    attribute_map = {
+        "id": "id",
+        "name": "name",
+        "members": "members",
+        "parent": "parent",
+    }
 
     def __init__(
             self,
             id: Optional[int] = None,
             name: Optional[str] = None,
             members: Optional[List[Contributor]] = None,
+            parent: Optional[int] = None,
     ):
         """Team - a model defined in OpenAPI
 
         :param id: The id of this Team.
         :param name: The name of this Team.
         :param members: The members of this Team.
+        :param parent: The parent of this Team.
         """
         self._id = id
         self._name = name
         self._members = members
+        self._parent = parent
 
     @property
     def id(self) -> int:
@@ -94,3 +107,23 @@ class Team(Model):
             raise ValueError("Invalid value for `members`, must not be `None`")
 
         self._members = members
+
+    @property
+    def parent(self) -> Optional[int]:
+        """Gets the parent of this Team.
+
+        Identifier of the higher level team.
+
+        :return: The parent of this Team.
+        """
+        return self._parent
+
+    @parent.setter
+    def parent(self, parent: Optional[int]):
+        """Sets the parent of this Team.
+
+        Identifier of the higher level team.
+
+        :param parent: The parent of this Team.
+        """
+        self._parent = parent

--- a/server/athenian/api/models/web/team_create_request.py
+++ b/server/athenian/api/models/web/team_create_request.py
@@ -6,12 +6,18 @@ from athenian.api.models.web.base_model_ import Model
 class TeamCreateRequest(Model):
     """Team creation request."""
 
-    openapi_types = {"account": int, "name": str, "members": List[str]}
+    openapi_types = {
+        "account": int,
+        "name": str,
+        "members": List[str],
+        "parent": int,
+    }
 
     attribute_map = {
         "account": "account",
         "name": "name",
         "members": "members",
+        "parent": "parent",
     }
 
     def __init__(
@@ -19,16 +25,19 @@ class TeamCreateRequest(Model):
             account: Optional[int] = None,
             name: Optional[str] = None,
             members: Optional[List[str]] = None,
+            parent: Optional[int] = None,
     ):
         """TeamCreateRequest - a model defined in OpenAPI
 
         :param account: The account of this TeamCreateRequest.
         :param name: The name of this TeamCreateRequest.
         :param members: The members of this TeamCreateRequest.
+        :param parent: The parent of this TeamCreateRequest.
         """
         self._account = account
         self._name = name
         self._members = members
+        self._parent = parent
 
     @property
     def account(self) -> int:
@@ -100,3 +109,23 @@ class TeamCreateRequest(Model):
             raise ValueError("Invalid value for `members`, must not be `None`")
 
         self._members = members
+
+    @property
+    def parent(self) -> Optional[int]:
+        """Gets the parent of this TeamCreateRequest.
+
+        Identifier of the higher level team.
+
+        :return: The parent of this TeamCreateRequest.
+        """
+        return self._parent
+
+    @parent.setter
+    def parent(self, parent: Optional[int]):
+        """Sets the parent of this TeamCreateRequest.
+
+        Identifier of the higher level team.
+
+        :param parent: The parent of this TeamCreateRequest.
+        """
+        self._parent = parent

--- a/server/athenian/api/models/web/team_update_request.py
+++ b/server/athenian/api/models/web/team_update_request.py
@@ -6,21 +6,32 @@ from athenian.api.models.web.base_model_ import Model
 class TeamUpdateRequest(Model):
     """Team update request."""
 
-    openapi_types = {"name": str, "members": List[str]}
-    attribute_map = {"name": "name", "members": "members"}
+    openapi_types = {
+        "name": str,
+        "members": List[str],
+        "parent": int,
+    }
+    attribute_map = {
+        "name": "name",
+        "members": "members",
+        "parent": "parent",
+    }
 
     def __init__(
             self,
             name: Optional[str] = None,
             members: Optional[List[str]] = None,
+            parent: Optional[int] = None,
     ):
         """TeamUpdateRequest - a model defined in OpenAPI
 
         :param name: The name of this TeamUpdateRequest.
         :param members: The members of this TeamUpdateRequest.
+        :param parent: The parent of this TeamUpdateRequest.
         """
         self._name = name
         self._members = members
+        self._parent = parent
 
     @property
     def name(self) -> str:
@@ -69,3 +80,23 @@ class TeamUpdateRequest(Model):
             raise ValueError("Invalid value for `members`, must not be `None`")
 
         self._members = members
+
+    @property
+    def parent(self) -> Optional[int]:
+        """Gets the parent of this TeamUpdateRequest.
+
+        New identifier of the higher level team.
+
+        :return: The parent of this TeamUpdateRequest.
+        """
+        return self._parent
+
+    @parent.setter
+    def parent(self, parent: Optional[int]):
+        """Sets the parent of this TeamUpdateRequest.
+
+        New identifier of the higher level team.
+
+        :param parent: The parent of this TeamUpdateRequest.
+        """
+        self._parent = parent

--- a/server/athenian/api/openapi/openapi.yaml
+++ b/server/athenian/api/openapi/openapi.yaml
@@ -2157,10 +2157,15 @@ components:
           type: string
         members:
           $ref: '#/components/schemas/DeveloperSet'
+        parent:
+          description: Identifier of the higher level team.
+          nullable: true
+          type: integer
       required:
       - account
       - members
       - name
+      - parent
       type: object
     TeamUpdateRequest:
       additionalProperties: false
@@ -2172,19 +2177,25 @@ components:
         - github.com/se7entyse7en
       properties:
         name:
-          description: Name of the team.
+          description: New name of the team.
           type: string
         members:
           $ref: '#/components/schemas/DeveloperSet'
+        parent:
+          description: New identifier of the higher level team.
+          nullable: true
+          type: integer
       required:
       - members
       - name
+      - parent
       type: object
     Team:
-      description: List of team members.
+      description: Definition of a team of several developers.
       example:
         id: 1
         name: Engineering
+        parent: 3
         members:
         - login: github.com/gkwillie
           name: Groundskeeper Willie
@@ -2203,16 +2214,22 @@ components:
           type: string
         members:
           $ref: '#/components/schemas/Contributors'
+        parent:
+          description: Identifier of the higher level team.
+          nullable: true
+          type: integer
       required:
       - id
       - members
       - name
+      - parent
       type: object
     TeamList:
       description: List of teams of an account.
       example:
       - id: 1
         name: Engineering
+        parent: 3
         members:
         - login: github.com/vmarkovtsev
           name: Vadim Markovtsev
@@ -2224,11 +2241,19 @@ components:
           picture: https://avatars1.githubusercontent.com/u/5599208?v=4
       - id: 2
         name: Product
+        parent: 3
         members:
         - login: github.com/warenlg
           name: Waren Long
           email: waren@athenian.co
           picture: https://avatars2.githubusercontent.com/u/24694845?v=4
+      - id: 3
+        name: Management
+        members:
+        - login: github.com/eiso
+          name: Eiso Kant
+          email: eiso@athenian.co
+          picture: https://avatars2.githubusercontent.com/u/1247608?v=4
       items:
         $ref: '#/components/schemas/Team'
       type: array

--- a/server/tests/controllers/test_team_controller.py
+++ b/server/tests/controllers/test_team_controller.py
@@ -332,7 +332,7 @@ async def test_get_team_smoke(client, headers, sdb):
     body = (await response.read()).decode("utf-8")
     assert response.status == 200, "Response body is : " + body
     body = json.loads(body)
-    assert body == {"id": 1, "name": "Engineering", "members": [
+    assert body == {"id": 1, "name": "Engineering", "parent": None, "members": [
         {"login": "github.com/mcuadros",
          "name": "Máximo Cuadros",
          "email": "mcuadros@gmail.com",


### PR DESCRIPTION
This specification change allows:
- Create a new team with an explicit parent.
- Update a team to set a new parent.
- List the teams with their hierarchy via the new `parent` field.