### PR TITLE
[DEV-1234] Add "impersonated_by"to /user

### DIFF
--- a/server/MANHOLE.md
+++ b/server/MANHOLE.md
@@ -4,7 +4,7 @@ API backdoor to execute arbitrary code in the requests.
 
 ### Where the code executes
 
-See `async def manhole()` in [athenian/api/__init__.py](athenian/api/__init__.py).
+See `async def manhole()` in [athenian/api/\_\_init\_\_.py](athenian/api/__init__.py).
 
 ### Writing the code
 

--- a/server/athenian/api/controllers/user_controller.py
+++ b/server/athenian/api/controllers/user_controller.py
@@ -26,6 +26,8 @@ from athenian.api.typing_utils import DatabaseLike
 async def get_user(request: AthenianWebRequest) -> web.Response:
     """Return details about the current user."""
     user = await (await request.user()).load_accounts(request.sdb)
+    if (god_id := getattr(request, "god_id", None)) is not None:
+        user.impersonated_by = god_id
     return model_response(user)
 
 

--- a/server/athenian/api/models/web/user.py
+++ b/server/athenian/api/models/web/user.py
@@ -21,6 +21,7 @@ class User(Model):
         "picture": Optional[str],
         "updated": Optional[str],
         "accounts": Optional[object],
+        "impersonated_by": Optional[str],
     }
 
     attribute_map = {
@@ -32,6 +33,7 @@ class User(Model):
         "picture": "picture",
         "updated": "updated",
         "accounts": "accounts",
+        "impersonated_by": "impersonated_by",
     }
 
     def __init__(
@@ -44,6 +46,7 @@ class User(Model):
         picture: Optional[str] = None,
         updated: Optional[datetime] = None,
         accounts: Optional[dict] = None,
+        impersonated_by: Optional[str] = None,
     ):
         """User - a model defined in OpenAPI
 
@@ -55,6 +58,7 @@ class User(Model):
         :param picture: The picture of this User.
         :param updated: The updated of this User.
         :param accounts: The accounts of this User.
+        :param impersonated_by: The impersonated_by of this User.
         """
         self._id = id
         self._native_id = native_id
@@ -64,6 +68,7 @@ class User(Model):
         self._picture = picture
         self._updated = updated
         self._accounts = accounts
+        self._impersonated_by = impersonated_by
 
     @classmethod
     def from_auth0(cls, name: str, nickname: str, picture: str, updated_at: str,
@@ -270,7 +275,6 @@ class User(Model):
         Mapping between account IDs the user is a member of and is_admin flags.
 
         :return: The accounts of this User.
-        :rtype: object
         """
         return self._accounts
 
@@ -283,3 +287,23 @@ class User(Model):
         :param accounts: The accounts of this User.
         """
         self._accounts = accounts
+
+    @property
+    def impersonated_by(self) -> Optional[str]:
+        """Gets the impersonated_by of this User.
+
+        Identifier of the god user who is acting on behalf of.
+
+        :return: The impersonated_by of this User.
+        """
+        return self._impersonated_by
+
+    @impersonated_by.setter
+    def impersonated_by(self, impersonated_by: Optional[str]):
+        """Sets the impersonated_by of this User.
+
+        Identifier of the god user who is acting on behalf of.
+
+        :param impersonated_by: The impersonated_by of this User.
+        """
+        self._impersonated_by = impersonated_by

--- a/server/athenian/api/openapi/openapi.yaml
+++ b/server/athenian/api/openapi/openapi.yaml
@@ -2390,6 +2390,9 @@ components:
             1: true
             2: false
           type: object
+        impersonated_by:
+          description: Identifier of the god user who is acting on behalf of.
+          type: string
       required:
       - id
       - login

--- a/server/tests/controllers/test_user_controller.py
+++ b/server/tests/controllers/test_user_controller.py
@@ -181,6 +181,8 @@ async def test_become_db(client, headers, sdb):
         method="GET", path="/v1/user", headers=headers, json={},
     )
     body2 = json.loads((await response.read()).decode("utf-8"))
+    assert body2["impersonated_by"] == "auth0|5e1f6dfb57bc640ea390557b"
+    del body2["impersonated_by"]
     assert body1 == body2
     del body1["updated"]
     assert body1 == {
@@ -227,6 +229,7 @@ async def test_become_header(client, headers, sdb):
         "native_id": "5e1f6e2e8bfa520ea5290741",
         "picture": "https://s.gravatar.com/avatar/dfe23533b671f82d2932e713b0477c75?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fei.png",  # noqa
         "accounts": {"1": False, "3": True},
+        "impersonated_by": "auth0|5e1f6dfb57bc640ea390557b",
     }
 
 


### PR DESCRIPTION
For gods, `User.impersonated_by` exists. It either equals to `User.id` (not active) or the real god ID.