### PR TITLE
Setup restart policy in docker compose for memcached and cloud sql proxy

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,6 +33,7 @@ services:
 
   memcached:
     image: launcher.gcr.io/google/memcached1
+    restart: unless-stopped
     command: ['memcached', '-m', '1024M', '-I', '128M']
     ports:
       - ${MEMCACHED_HOST_PORT:-11211}:11211
@@ -55,6 +56,7 @@ services:
 
   cloud_sql_proxy:
     image: atholeque/goterracloud
+    restart: unless-stopped
     command: [
       'cloud_sql_proxy',
       '-instances=${CLOUD_SQL_INSTANCE}=tcp:0.0.0.0:5432',


### PR DESCRIPTION
For some unknown reasons, in pre-staging environment, those containers are exiting with code 0 without anyone stopping them. This should at least make them restart in case it happens.