### PR TITLE
Preloading tooling

### DIFF
--- a/server/athenian/api/db.py
+++ b/server/athenian/api/db.py
@@ -5,8 +5,9 @@ import os
 import pickle
 import re
 import sys
+import threading
 import time
-from typing import Any, Callable, List, Mapping, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
 from urllib.parse import quote
 
 import aiohttp.web
@@ -19,6 +20,9 @@ from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.functions import ReturnTypeFromArgs
 
 from athenian.api import metadata
+from athenian.api.models import check_alembic_schema_version, check_collation, \
+    DBSchemaMismatchError
+from athenian.api.models.metadata import check_schema_version as check_mdb_schema_version
 from athenian.api.slogging import log_multipart
 from athenian.api.tracing import MAX_SENTRY_STRING_LENGTH
 from athenian.api.typing_utils import wraps
@@ -338,3 +342,63 @@ class greatest(ReturnTypeFromArgs):  # noqa
 
 class least(ReturnTypeFromArgs):  # noqa
     """SQL LEAST function."""
+
+
+def check_schema_versions(metadata_db: str,
+                          state_db: str,
+                          precomputed_db: str,
+                          persistentdata_db: str,
+                          log: logging.Logger,
+                          ) -> bool:
+    """Validate schema versions in parallel threads."""
+    passed = True
+    logging.getLogger("alembic.runtime.migration").setLevel(logging.WARNING)
+
+    def check_alembic(name, cs):
+        nonlocal passed
+        try:
+            check_alembic_schema_version(name, cs, log)
+            check_collation(cs)
+        except DBSchemaMismatchError as e:
+            passed = False
+            log.error("%s schema version check failed: %s", name, e)
+        except Exception:
+            passed = False
+            log.exception("while checking %s", name)
+
+    def check_metadata(cs):
+        nonlocal passed
+        try:
+            check_mdb_schema_version(cs, log)
+            check_collation(cs)
+        except DBSchemaMismatchError as e:
+            passed = False
+            log.error("metadata schema version check failed: %s", e)
+        except Exception:
+            passed = False
+            log.exception("while checking metadata")
+
+    checkers = [threading.Thread(target=check_alembic, args=args)
+                for args in (("state", state_db),
+                             ("precomputed", precomputed_db),
+                             ("persistentdata", persistentdata_db),
+                             )]
+    checkers.append(threading.Thread(target=check_metadata, args=(metadata_db,)))
+    for t in checkers:
+        t.start()
+    for t in checkers:
+        t.join()
+    return passed
+
+
+def compose_db_options(mdb: str, sdb: str, pdb: str, rdb: str) -> Dict[str, Dict[str, Any]]:
+    """Create the kwargs for each of the three databases.Database __init__-s."""
+    result = {"mdb_options": {},
+              "sdb_options": {},
+              "pdb_options": {},
+              "rdb_options": {}}
+    for url, dikt in zip((mdb, sdb, pdb, rdb), result.values()):
+        if databases.DatabaseURL(url).dialect in ("postgres", "postgresql"):
+            # enable PgBouncer
+            dikt["statement_cache_size"] = 0
+    return result

--- a/server/athenian/api/preloading/__main__.py
+++ b/server/athenian/api/preloading/__main__.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+import argparse
+import asyncio
+import logging
+import sys
+import textwrap
+
+from athenian.api import metadata
+from athenian.api.async_utils import gather
+from athenian.api.db import check_schema_versions, compose_db_options, ParallelDatabase
+from athenian.api.preloading.cache import MemoryCachePreloader
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse the command line and return the parsed arguments."""
+    parser = argparse.ArgumentParser(metadata.__package__)
+
+    parser.add_argument("--metadata-db",
+                        default="postgresql://postgres:postgres@0.0.0.0:5432/metadata",
+                        help="Metadata (GitHub, JIRA, etc.) DB connection string in SQLAlchemy "
+                             "format. This DB is readonly.")
+    parser.add_argument("--state-db",
+                        default="postgresql://postgres:postgres@0.0.0.0:5432/state",
+                        help="Server state (user settings, teams, etc.) DB connection string in "
+                             "SQLAlchemy format. This DB is read/write.")
+    parser.add_argument("--precomputed-db",
+                        default="postgresql://postgres:postgres@0.0.0.0:5432/precomputed",
+                        help="Precomputed objects augmenting the metadata DB and reducing "
+                             "the amount of online work. DB connection string in SQLAlchemy "
+                             "format. This DB is read/write.")
+    parser.add_argument("--persistentdata-db",
+                        default="postgresql://postgres:postgres@0.0.0.0:5432/persistentdata",
+                        help="Pushed and pulled source data that Athenian owns. DB connection "
+                             "string in SQLAlchemy format. This DB is read/write.")
+    parser.add_argument("--detailed", required=False, action="store_true",
+                        help="Whether to also show the memory usage of each column.")
+
+    return parser.parse_args()
+
+
+def main():
+    """Print memory usage for preloaded DataFrames."""
+    args = parse_args()
+    log = logging.getLogger(metadata.__package__)
+    if not check_schema_versions(args.metadata_db,
+                                 args.state_db,
+                                 args.precomputed_db,
+                                 args.persistentdata_db,
+                                 log):
+        return None
+
+    db_conns = {
+        "sdb": args.state_db,
+        "mdb": args.metadata_db,
+        "pdb": args.precomputed_db,
+        "rdb": args.persistentdata_db,
+    }
+    db_options = compose_db_options(args.metadata_db,
+                                    args.state_db,
+                                    args.precomputed_db,
+                                    args.persistentdata_db)
+
+    return asyncio.run(_main(db_conns, db_options, args.detailed))
+
+
+async def _main(db_conns: dict, db_options: dict, detailed: bool):
+    tasks, dbs = [], {}
+    for db_shortcut, db_conn in db_conns.items():
+        db = ParallelDatabase(db_conn, **db_options[f"{db_shortcut}_options"])
+        tasks.append(db.connect())
+        dbs[db_shortcut] = db
+
+    await gather(*tasks)
+
+    mc = MemoryCachePreloader()
+    mc.preload(detailed, **dbs)
+    await mc._task
+
+    for db_name, db in dbs.items():
+        if not (cache := getattr(db, "cache", None)):
+            continue
+
+        db_total_mem = cache.memory_usage(True, True)
+        print(_summary_line(f"DB: {db_name}", 1, db_total_mem))
+        for name, df in cache.dfs.items():
+            total_mem = df.memory_usage(True, True)
+            print(_summary_line(f"DataFrame: {name}", 2, total_mem))
+            if not detailed:
+                continue
+
+            for key in ("raw", "processed", "percentage"):
+                print(f"{_detail(key, df._mem)}\n")
+
+
+def _summary_line(title, indent_level, total=None):
+    prefix = "#" * indent_level
+    s = f"{(prefix + ' ' + title):<50}"
+    if total:
+        s = f"{s} | [total: {total}]"
+
+    return s + "\n"
+
+
+def _detail(key, info):
+    name = key.title()
+    lines = [
+        _summary_line(name, 3, info[key]["total"]),
+        _summary_line(f"{name} series", 3),
+        textwrap.indent(str(info[key]["series"]), " " * 4),
+    ]
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a script to assess memory usage of preloaded DataFrames.

This is the output when ran against prod DB with [this options](https://github.com/athenianco/athenian-api/pull/1337/files#diff-57022c74cc59d401d7a1ec3d23077a91a73f2224a74f9f7b22feea1080189e6bR275):
```
python3 -m athenian.api.preloading --metadata-db=postgresql://***:***@localhost:5435/metadata --state-db=postgresql://***:***@localhost:5435/state --precomputed-db=postgresql://***:***@localhost:5435/precomputed --persistentdata-db=postgresql://***:***@localhost:5435/persistentdata --detailed
- DB: mdb                           | [total: 238.98 MiB]
-- DataFrame: prs                   | [total: 238.98 MiB]
--- Raw                             | [total: 526318360]
--- Raw series
Index                        128
acc_id                   6258984
node_id                 69630425
number                   6258984
closed                    782373
closed_at                6258984
created_at               6258984
merged                    782373
merge_commit_id         92474425
merge_commit_sha        66715833
merged_at                6258984
merged_by_login         48507980
repository_full_name    60942880
updated_at               6258984
user_login              52287193
hidden                    782373
additions                6258984
deletions                6258984
htmlurl                 83340505
dtype: int64
--- Processed                       | [total: 250585343]
--- Processed series
Index                        128
acc_id                    785357
node_id                 25035936
number                   6258984
closed                    782373
closed_at                6258984
created_at               6258984
merged                    782373
merge_commit_id         62589840
merge_commit_sha        31294920
merged_at                6258984
merged_by_login          1982919
repository_full_name     2079188
updated_at               6258984
user_login               2419748
hidden                    782373
additions                6258984
deletions                6258984
htmlurl                 78237300
dtype: int64
--- Percentage                      | [total: 47.610982637960795]
--- Percentage series
Index                   100.000000
acc_id                   12.547675
node_id                  35.955455
number                  100.000000
closed                  100.000000
closed_at               100.000000
created_at              100.000000
merged                  100.000000
merge_commit_id          67.683405
merge_commit_sha         46.907786
merged_at               100.000000
merged_by_login           4.087820
repository_full_name      3.411700
updated_at              100.000000
user_login                4.627802
hidden                  100.000000
additions               100.000000
deletions               100.000000
htmlurl                  93.876681
dtype: float64
```

Adding this script turned out to have the right timing. The reason is that the size that during my experiments was lower, because I was not preloading some columns that are indeed not used during filtering (more on this later). Some thoughts ordered by how easily we can deal with this:
- we'll probably be "forced" to indeed enable this only to big accounts to save memory. I didn't check for Faire, but for example of our own data, it's only 1.1MiB. Assuming a Pareto maybe we could save something around 20%?
- some of those fields could  probably be removed, for example, `htmlurl` is used only for being printed in a validation error and that will be already ~70MiB saved,
- some of those fields are not used during filtering (at least not in the porting implemented [here](https://github.com/athenianco/athenian-api/pull/1337)), and some of them are very memory-expansive such as `merge_commit_id` and `merge_commit_sha`, this means that we could avoid preloading them, and "attach" them post-filtering using other means (such as RocksDB or similar as initially suggested in the [slides](https://docs.google.com/presentation/d/1oaFRBdUslpiT7jQv_0e3zH9N4RumNixBz4SAXQajKDc/edit)), this would save a lot of memory: `htmlurl` + `merge_commit_id` + `merge_commit_sha` = ~165MiB,
- find a way to centralize the memory usage either using Memcached or going hardcore and split this part from API, but then it would be better to really rethink the architecture if we reach this point.

On the other hand, this is not yet a blocker, but we can still continue with the current approach, but keep this in our mind. I'll launch this script for each new preloaded DataFrame.