### PR TITLE
Overridable PRs to releases and viceversa mappers and releases loader

### DIFF
--- a/server/athenian/api/controllers/miners/github/release_load.py
+++ b/server/athenian/api/controllers/miners/github/release_load.py
@@ -18,7 +18,7 @@ from sqlalchemy.sql import ClauseElement
 
 from athenian.api import metadata
 from athenian.api.async_utils import gather, read_sql_query
-from athenian.api.cache import cached
+from athenian.api.cache import cached, cached_methods
 from athenian.api.controllers.miners.github.branches import load_branch_commit_dates
 from athenian.api.controllers.miners.github.commit import BRANCH_FETCH_COMMITS_COLUMNS, \
     fetch_precomputed_commit_history_dags, \
@@ -42,253 +42,568 @@ tag_by_branch_probe_lookaround = timedelta(weeks=4)
 unfresh_releases_threshold = 50
 
 
-@sentry_span
-async def load_releases(repos: Iterable[str],
-                        branches: pd.DataFrame,
-                        default_branches: Dict[str, str],
-                        time_from: datetime,
-                        time_to: datetime,
-                        settings: ReleaseSettings,
-                        account: int,
-                        meta_ids: Tuple[int, ...],
-                        mdb: databases.Database,
-                        pdb: databases.Database,
-                        rdb: databases.Database,
-                        cache: Optional[aiomcache.Client],
-                        index: Optional[Union[str, Sequence[str]]] = None,
-                        force_fresh: bool = False,
-                        ) -> Tuple[pd.DataFrame, Dict[str, ReleaseMatch]]:
-    """
-    Fetch releases from the metadata DB according to the match settings.
+class ReleaseLoader:
+    """Loader for releases."""
 
-    :param repos: Repositories in which to search for releases *without the service prefix*.
-    :param account: Account ID of the releases' owner. Needed to query persistentdata.
-    :param branches: DataFrame with all the branches in `repos`.
-    :param default_branches: Mapping from repository name to default branch name.
-    :return: 1. Pandas DataFrame with the loaded releases (columns match the Release model + \
-                `matched_by_column`.)
-             2. map from repository names (without the service prefix) to the effective matches.
-    """
-    assert isinstance(mdb, databases.Database)
-    assert isinstance(pdb, databases.Database)
-    assert isinstance(rdb, databases.Database)
-    assert time_from <= time_to
+    @classmethod
+    @sentry_span
+    async def load_releases(cls,
+                            repos: Iterable[str],
+                            branches: pd.DataFrame,
+                            default_branches: Dict[str, str],
+                            time_from: datetime,
+                            time_to: datetime,
+                            settings: ReleaseSettings,
+                            account: int,
+                            meta_ids: Tuple[int, ...],
+                            mdb: databases.Database,
+                            pdb: databases.Database,
+                            rdb: databases.Database,
+                            cache: Optional[aiomcache.Client],
+                            index: Optional[Union[str, Sequence[str]]] = None,
+                            force_fresh: bool = False,
+                            ) -> Tuple[pd.DataFrame, Dict[str, ReleaseMatch]]:
+        """
+        Fetch releases from the metadata DB according to the match settings.
 
-    log = logging.getLogger("%s.load_releases" % metadata.__package__)
-    match_groups, event_repos, repos_count = group_repos_by_release_match(
-        repos, default_branches, settings)
-    if repos_count == 0:
-        log.warning("no repositories")
-        return dummy_releases_df(), {}
-    # the order is critically important! first fetch the spans, then the releases
-    # because when the update transaction commits, we can be otherwise half-way through
-    # strictly speaking, there is still no guarantee with our order, but it is enough for
-    # passing the unit tests
-    tasks = [
-        fetch_precomputed_release_match_spans(match_groups, account, pdb),
-        _fetch_precomputed_releases(
-            match_groups,
-            time_from - tag_by_branch_probe_lookaround,
-            time_to + tag_by_branch_probe_lookaround,
-            account, pdb, index=index),
-        _fetch_release_events(event_repos, account, meta_ids, time_from, time_to, mdb, rdb),
-    ]
-    spans, releases, event_releases = await gather(*tasks)
+        :param repos: Repositories in which to search for releases *without the service prefix*.
+        :param account: Account ID of the releases' owner. Needed to query persistentdata.
+        :param branches: DataFrame with all the branches in `repos`.
+        :param default_branches: Mapping from repository name to default branch name.
+        :return: 1. Pandas DataFrame with the loaded releases (columns match the Release model + \
+                    `matched_by_column`.)
+                 2. map from repository names (without the service prefix) to the effective
+                    matches.
+        """
+        assert isinstance(mdb, databases.Database)
+        assert isinstance(pdb, databases.Database)
+        assert isinstance(rdb, databases.Database)
+        assert time_from <= time_to
 
-    def gather_applied_matches() -> Dict[str, ReleaseMatch]:
-        # nlargest(1) puts `tag` in front of `branch` for `tag_or_branch` repositories with both
-        # options precomputed
-        # We cannot use nlargest(1) because it produces an inconsistent index:
-        # we don't have repository_full_name when there is only one release.
-        matches = releases[[Release.repository_full_name.key, matched_by_column]].groupby(
-            Release.repository_full_name.key, sort=False,
-        )[matched_by_column].apply(lambda s: s[s.astype(int).idxmax()]).to_dict()
-        for repo in event_repos:
-            matches[repo] = ReleaseMatch.event
-        return matches
+        log = logging.getLogger("%s.load_releases" % metadata.__package__)
+        match_groups, event_repos, repos_count = group_repos_by_release_match(
+            repos, default_branches, settings)
+        if repos_count == 0:
+            log.warning("no repositories")
+            return dummy_releases_df(), {}
+        # the order is critically important! first fetch the spans, then the releases
+        # because when the update transaction commits, we can be otherwise half-way through
+        # strictly speaking, there is still no guarantee with our order, but it is enough for
+        # passing the unit tests
+        tasks = [
+            cls.fetch_precomputed_release_match_spans(match_groups, account, pdb),
+            cls._fetch_precomputed_releases(
+                match_groups,
+                time_from - tag_by_branch_probe_lookaround,
+                time_to + tag_by_branch_probe_lookaround,
+                account, pdb, index=index),
+            cls._fetch_release_events(event_repos, account, meta_ids, time_from, time_to, mdb,
+                                      rdb),
+        ]
+        spans, releases, event_releases = await gather(*tasks)
 
-    applied_matches = gather_applied_matches()
-    if force_fresh:
-        max_time_to = datetime.now(timezone.utc) + timedelta(days=1)
-    else:
-        max_time_to = datetime.now(timezone.utc).replace(minute=0, second=0)
-        if repos_count > unfresh_releases_threshold:
-            log.warning("Activated the unfresh mode for a set of %d repositories", repos_count)
-            max_time_to -= timedelta(hours=1)
-    settings = settings.copy()
-    for full_repo, setting in settings.prefixed.items():
-        repo = full_repo.split("/", 1)[1]
-        try:
-            match = applied_matches[repo]
-        except KeyError:
-            # there can be repositories with 0 releases in the range but which are precomputed
-            applied_matches[repo] = setting.match
+        def gather_applied_matches() -> Dict[str, ReleaseMatch]:
+            # nlargest(1) puts `tag` in front of `branch` for `tag_or_branch` repositories with
+            # both options precomputed
+            # We cannot use nlargest(1) because it produces an inconsistent index:
+            # we don't have repository_full_name when there is only one release.
+            matches = releases[[Release.repository_full_name.key, matched_by_column]].groupby(
+                Release.repository_full_name.key, sort=False,
+            )[matched_by_column].apply(lambda s: s[s.astype(int).idxmax()]).to_dict()
+            for repo in event_repos:
+                matches[repo] = ReleaseMatch.event
+            return matches
+
+        applied_matches = gather_applied_matches()
+        if force_fresh:
+            max_time_to = datetime.now(timezone.utc) + timedelta(days=1)
         else:
-            if setting.match == ReleaseMatch.tag_or_branch:
-                if match == ReleaseMatch.tag:
-                    settings.set_by_prefixed(full_repo, ReleaseMatchSetting(
-                        tags=setting.tags, branches=setting.branches, match=ReleaseMatch.tag))
-                    applied_matches[repo] = ReleaseMatch.tag
-                else:
-                    # having precomputed branch releases when we want tags does not mean anything
-                    applied_matches[repo] = ReleaseMatch.tag_or_branch
-            else:
-                applied_matches[repo] = ReleaseMatch(match)
-    missing_high = []
-    missing_low = []
-    missing_all = []
-    hits = 0
-    ambiguous_branches_scanned = set()
-    for repo in repos:
-        applied_match = applied_matches[repo]
-        if applied_match == ReleaseMatch.tag_or_branch:
-            matches = (ReleaseMatch.branch, ReleaseMatch.tag)
-            ambiguous_branches_scanned.add(repo)
-        elif applied_match == ReleaseMatch.event:
-            continue
-        else:
-            matches = (applied_match,)
-        for match in matches:
+            max_time_to = datetime.now(timezone.utc).replace(minute=0, second=0)
+            if repos_count > unfresh_releases_threshold:
+                log.warning("Activated the unfresh mode for a set of %d repositories", repos_count)
+                max_time_to -= timedelta(hours=1)
+        settings = settings.copy()
+        for full_repo, setting in settings.prefixed.items():
+            repo = full_repo.split("/", 1)[1]
             try:
-                rt_from, rt_to = spans[repo][match]
+                match = applied_matches[repo]
             except KeyError:
-                missing_all.append((repo, match))
+                # there can be repositories with 0 releases in the range but which are precomputed
+                applied_matches[repo] = setting.match
+            else:
+                if setting.match == ReleaseMatch.tag_or_branch:
+                    if match == ReleaseMatch.tag:
+                        settings.set_by_prefixed(full_repo, ReleaseMatchSetting(
+                            tags=setting.tags, branches=setting.branches, match=ReleaseMatch.tag))
+                        applied_matches[repo] = ReleaseMatch.tag
+                    else:
+                        # having precomputed branch releases when we want tags does not mean
+                        # anything
+                        applied_matches[repo] = ReleaseMatch.tag_or_branch
+                else:
+                    applied_matches[repo] = ReleaseMatch(match)
+        missing_high = []
+        missing_low = []
+        missing_all = []
+        hits = 0
+        ambiguous_branches_scanned = set()
+        for repo in repos:
+            applied_match = applied_matches[repo]
+            if applied_match == ReleaseMatch.tag_or_branch:
+                matches = (ReleaseMatch.branch, ReleaseMatch.tag)
+                ambiguous_branches_scanned.add(repo)
+            elif applied_match == ReleaseMatch.event:
                 continue
-            assert rt_from <= rt_to
-            my_time_from = time_from
-            my_time_to = time_to
-            if applied_match == ReleaseMatch.tag_or_branch and match == ReleaseMatch.tag:
-                my_time_from -= tag_by_branch_probe_lookaround
-                my_time_to += tag_by_branch_probe_lookaround
-            my_time_to = min(my_time_to, max_time_to)
-            missed = False
-            if my_time_from < rt_from <= my_time_to:
-                missing_low.append((rt_from, (repo, match)))
-                missed = True
-            if my_time_from <= rt_to < my_time_to:
-                # DEV-990: ensure some gap to avoid failing when mdb lags
-                missing_high.append((rt_to - timedelta(hours=1), (repo, match)))
-                missed = True
-            if rt_from > my_time_to or rt_to < my_time_from:
-                missing_all.append((repo, match))
-                missed = True
-            if not missed:
-                hits += 1
-    add_pdb_hits(pdb, "releases", hits)
-    tasks = []
-    if missing_high:
-        missing_high.sort()
-        tasks.append(_load_releases(
-            [r for _, r in missing_high], branches, default_branches, missing_high[0][0], time_to,
-            settings, account, meta_ids, mdb, pdb, cache, index=index))
-        add_pdb_misses(pdb, "releases/high", len(missing_high))
-    if missing_low:
-        missing_low.sort()
-        tasks.append(_load_releases(
-            [r for _, r in missing_low], branches, default_branches, time_from, missing_low[-1][0],
-            settings, account, meta_ids, mdb, pdb, cache, index=index))
-        add_pdb_misses(pdb, "releases/low", len(missing_low))
-    if missing_all:
-        tasks.append(_load_releases(
-            missing_all, branches, default_branches, time_from, time_to,
-            settings, account, meta_ids, mdb, pdb, cache, index=index))
-        add_pdb_misses(pdb, "releases/all", len(missing_all))
-    if tasks:
-        missings = await gather(*tasks)
-        missings = pd.concat(missings, copy=False)
-        releases = pd.concat([releases, missings], copy=False)
+            else:
+                matches = (applied_match,)
+            for match in matches:
+                try:
+                    rt_from, rt_to = spans[repo][match]
+                except KeyError:
+                    missing_all.append((repo, match))
+                    continue
+                assert rt_from <= rt_to
+                my_time_from = time_from
+                my_time_to = time_to
+                if applied_match == ReleaseMatch.tag_or_branch and match == ReleaseMatch.tag:
+                    my_time_from -= tag_by_branch_probe_lookaround
+                    my_time_to += tag_by_branch_probe_lookaround
+                my_time_to = min(my_time_to, max_time_to)
+                missed = False
+                if my_time_from < rt_from <= my_time_to:
+                    missing_low.append((rt_from, (repo, match)))
+                    missed = True
+                if my_time_from <= rt_to < my_time_to:
+                    # DEV-990: ensure some gap to avoid failing when mdb lags
+                    missing_high.append((rt_to - timedelta(hours=1), (repo, match)))
+                    missed = True
+                if rt_from > my_time_to or rt_to < my_time_from:
+                    missing_all.append((repo, match))
+                    missed = True
+                if not missed:
+                    hits += 1
+        add_pdb_hits(pdb, "releases", hits)
+        tasks = []
+        if missing_high:
+            missing_high.sort()
+            tasks.append(cls._load_releases(
+                [r for _, r in missing_high], branches, default_branches, missing_high[0][0],
+                time_to, settings, account, meta_ids, mdb, pdb, cache, index=index))
+            add_pdb_misses(pdb, "releases/high", len(missing_high))
+        if missing_low:
+            missing_low.sort()
+            tasks.append(cls._load_releases(
+                [r for _, r in missing_low], branches, default_branches, time_from,
+                missing_low[-1][0], settings, account, meta_ids, mdb, pdb, cache, index=index))
+            add_pdb_misses(pdb, "releases/low", len(missing_low))
+        if missing_all:
+            tasks.append(cls._load_releases(
+                missing_all, branches, default_branches, time_from, time_to,
+                settings, account, meta_ids, mdb, pdb, cache, index=index))
+            add_pdb_misses(pdb, "releases/all", len(missing_all))
+        if tasks:
+            missings = await gather(*tasks)
+            missings = pd.concat(missings, copy=False)
+            releases = pd.concat([releases, missings], copy=False)
+            if index is not None:
+                releases = releases.take(np.where(~releases.index.duplicated())[0])
+            else:
+                releases.drop_duplicates(Release.id.key, inplace=True, ignore_index=True)
+            releases.sort_values(Release.published_at.key,
+                                 inplace=True, ascending=False, ignore_index=True)
+        applied_matches = gather_applied_matches()
+        for r in repos:
+            if r in applied_matches:
+                continue
+            # no releases were loaded for this repository
+            match = settings.native[r].match
+            if match == ReleaseMatch.tag_or_branch:
+                match = ReleaseMatch.branch
+            applied_matches[r] = match
+        if tasks:
+            async def store_precomputed_releases():
+                # we must execute these in sequence to stay consistent
+                async with pdb.connection() as pdb_conn:
+                    # the updates must be integer so we take a transaction
+                    async with pdb_conn.transaction():
+                        await cls._store_precomputed_releases(
+                            missings, default_branches, settings, account, pdb_conn)
+                        # if we know that we've scanned branches for `tag_or_branch`, no matter if
+                        # we loaded tags or not, we should update the span
+                        matches = applied_matches.copy()
+                        for repo in ambiguous_branches_scanned:
+                            matches[repo] = ReleaseMatch.branch
+                        await cls._store_precomputed_release_match_spans(
+                            match_groups, matches, time_from, time_to, account, pdb_conn)
+
+            await defer(store_precomputed_releases(),
+                        "store_precomputed_releases(%d, %d)" % (len(missings), repos_count))
+
+        # we could have loaded both branch and tag releases for `tag_or_branch`, erase the errors
+        repos_vec = releases[Release.repository_full_name.key].values.astype("S")
+        published_at = releases[Release.published_at.key]
+        matched_by_vec = releases[matched_by_column].values
+        errors = np.full(len(releases), False)
+        for repo, match in applied_matches.items():
+            if settings.native[repo].match == ReleaseMatch.tag_or_branch:
+                errors |= (repos_vec == repo.encode()) & (matched_by_vec != match)
+        include = ~errors & (published_at >= time_from).values & (published_at < time_to).values
+        releases = releases.take(np.nonzero(include)[0])
+        if Release.acc_id.key in releases:
+            del releases[Release.acc_id.key]
+        # append the pushed releases
+        if not event_releases.empty:
+            releases = pd.concat([releases, event_releases], copy=False)
+            releases.sort_values(Release.published_at.key,
+                                 inplace=True, ascending=False, ignore_index=True)
+        return releases, applied_matches
+
+    @classmethod
+    @sentry_span
+    async def fetch_precomputed_release_match_spans(
+            cls,
+            match_groups: Dict[ReleaseMatch, Dict[str, List[str]]],
+            account: int,
+            pdb: databases.Database) -> Dict[str, Dict[str, Tuple[datetime, datetime]]]:
+        """Find out the precomputed time intervals for each release match group of repositories."""
+        ghrts = GitHubReleaseMatchTimespan
+        sqlite = pdb.url.dialect == "sqlite"
+        or_items, _ = match_groups_to_sql(match_groups, ghrts)
+        if pdb.url.dialect == "sqlite":
+            query = (
+                select([ghrts.repository_full_name, ghrts.release_match,
+                        ghrts.time_from, ghrts.time_to])
+                .where(and_(or_(*or_items), ghrts.acc_id == account))
+            )
+        else:
+            query = union_all(*(
+                select([ghrts.repository_full_name, ghrts.release_match,
+                        ghrts.time_from, ghrts.time_to])
+                .where(and_(item, ghrts.acc_id == account))
+                for item in or_items))
+        rows = await pdb.fetch_all(query)
+        spans = {}
+        for row in rows:
+            if row[ghrts.release_match.key].startswith("tag|"):
+                release_match = ReleaseMatch.tag
+            else:
+                release_match = ReleaseMatch.branch
+            times = row[ghrts.time_from.key], row[ghrts.time_to.key]
+            if sqlite:
+                times = tuple(t.replace(tzinfo=timezone.utc) for t in times)
+            spans.setdefault(row[ghrts.repository_full_name.key], {})[release_match] = times
+        return spans
+
+    @classmethod
+    @sentry_span
+    async def _load_releases(cls,
+                             repos: Iterable[Tuple[str, ReleaseMatch]],
+                             branches: pd.DataFrame,
+                             default_branches: Dict[str, str],
+                             time_from: datetime,
+                             time_to: datetime,
+                             settings: ReleaseSettings,
+                             account: int,
+                             meta_ids: Tuple[int, ...],
+                             mdb: databases.Database,
+                             pdb: databases.Database,
+                             cache: Optional[aiomcache.Client],
+                             index: Optional[Union[str, Sequence[str]]] = None,
+                             ) -> pd.DataFrame:
+        rel_matcher = ReleaseMatcher(account, meta_ids, mdb, pdb, cache)
+        repos_by_tag = []
+        repos_by_branch = []
+        for repo, match in repos:
+            if match == ReleaseMatch.tag:
+                repos_by_tag.append(repo)
+            elif match == ReleaseMatch.branch:
+                repos_by_branch.append(repo)
+            else:
+                raise AssertionError("Invalid release match: %s" % match)
+        result = []
+        if repos_by_tag:
+            result.append(rel_matcher.match_releases_by_tag(
+                repos_by_tag, time_from, time_to, settings))
+        if repos_by_branch:
+            result.append(rel_matcher.match_releases_by_branch(
+                repos_by_branch, branches, default_branches, time_from, time_to, settings))
+        result = await gather(*result)
+        result = pd.concat(result) if result else dummy_releases_df()
         if index is not None:
-            releases = releases.take(np.where(~releases.index.duplicated())[0])
+            result.set_index(index, inplace=True)
         else:
-            releases.drop_duplicates(Release.id.key, inplace=True, ignore_index=True)
-        releases.sort_values(Release.published_at.key,
-                             inplace=True, ascending=False, ignore_index=True)
-    applied_matches = gather_applied_matches()
-    for r in repos:
-        if r in applied_matches:
-            continue
-        # no releases were loaded for this repository
-        match = settings.native[r].match
-        if match == ReleaseMatch.tag_or_branch:
-            match = ReleaseMatch.branch
-        applied_matches[r] = match
-    if tasks:
-        async def store_precomputed_releases():
-            # we must execute these in sequence to stay consistent
-            async with pdb.connection() as pdb_conn:
-                # the updates must be integer so we take a transaction
-                async with pdb_conn.transaction():
-                    await _store_precomputed_releases(
-                        missings, default_branches, settings, account, pdb_conn)
-                    # if we know that we've scanned branches for `tag_or_branch`, no matter if
-                    # we loaded tags or not, we should update the span
-                    matches = applied_matches.copy()
-                    for repo in ambiguous_branches_scanned:
-                        matches[repo] = ReleaseMatch.branch
-                    await _store_precomputed_release_match_spans(
-                        match_groups, matches, time_from, time_to, account, pdb_conn)
+            result.reset_index(drop=True, inplace=True)
+        return result
 
-        await defer(store_precomputed_releases(),
-                    "store_precomputed_releases(%d, %d)" % (len(missings), repos_count))
-
-    # we could have loaded both branch and tag releases for `tag_or_branch`, erase the errors
-    repos_vec = releases[Release.repository_full_name.key].values.astype("S")
-    published_at = releases[Release.published_at.key]
-    matched_by_vec = releases[matched_by_column].values
-    errors = np.full(len(releases), False)
-    for repo, match in applied_matches.items():
-        if settings.native[repo].match == ReleaseMatch.tag_or_branch:
-            errors |= (repos_vec == repo.encode()) & (matched_by_vec != match)
-    include = ~errors & (published_at >= time_from).values & (published_at < time_to).values
-    releases = releases.take(np.nonzero(include)[0])
-    if Release.acc_id.key in releases:
-        del releases[Release.acc_id.key]
-    # append the pushed releases
-    if not event_releases.empty:
-        releases = pd.concat([releases, event_releases], copy=False)
-        releases.sort_values(Release.published_at.key,
-                             inplace=True, ascending=False, ignore_index=True)
-    return releases, applied_matches
-
-
-@sentry_span
-async def _load_releases(repos: Iterable[Tuple[str, ReleaseMatch]],
-                         branches: pd.DataFrame,
-                         default_branches: Dict[str, str],
-                         time_from: datetime,
-                         time_to: datetime,
-                         settings: ReleaseSettings,
-                         account: int,
-                         meta_ids: Tuple[int, ...],
-                         mdb: databases.Database,
-                         pdb: databases.Database,
-                         cache: Optional[aiomcache.Client],
-                         index: Optional[Union[str, Sequence[str]]] = None,
-                         ) -> pd.DataFrame:
-    repos_by_tag = []
-    repos_by_branch = []
-    for repo, match in repos:
-        if match == ReleaseMatch.tag:
-            repos_by_tag.append(repo)
-        elif match == ReleaseMatch.branch:
-            repos_by_branch.append(repo)
+    @classmethod
+    @sentry_span
+    async def _fetch_precomputed_releases(cls,
+                                          match_groups: Dict[ReleaseMatch, Dict[str, List[str]]],
+                                          time_from: datetime,
+                                          time_to: datetime,
+                                          account: int,
+                                          pdb: databases.Database,
+                                          index: Optional[Union[str, Sequence[str]]] = None,
+                                          ) -> pd.DataFrame:
+        prel = PrecomputedRelease
+        or_items, _ = match_groups_to_sql(match_groups, prel)
+        if pdb.url.dialect == "sqlite":
+            query = (
+                select([prel])
+                .where(and_(or_(*or_items) if or_items else false(),
+                            prel.published_at.between(time_from, time_to),
+                            prel.acc_id == account))
+                .order_by(desc(prel.published_at))
+            )
         else:
-            raise AssertionError("Invalid release match: %s" % match)
-    result = []
-    if repos_by_tag:
-        result.append(_match_releases_by_tag(
-            repos_by_tag, time_from, time_to, settings, meta_ids, mdb))
-    if repos_by_branch:
-        result.append(_match_releases_by_branch(
-            repos_by_branch, branches, default_branches, time_from, time_to, settings,
-            account, meta_ids, mdb, pdb, cache))
-    result = await gather(*result)
-    result = pd.concat(result) if result else dummy_releases_df()
-    if index is not None:
-        result.set_index(index, inplace=True)
-    else:
-        result.reset_index(drop=True, inplace=True)
-    return result
+            query = union_all(*(
+                select([prel])
+                .where(and_(item,
+                            prel.published_at.between(time_from, time_to),
+                            prel.acc_id == account))
+                .order_by(desc(prel.published_at))
+                for item in or_items))
+        df = await read_sql_query(query, pdb, prel)
+        df = remove_ambigous_precomputed_releases(df, prel.repository_full_name.key)
+        if index is not None:
+            df.set_index(index, inplace=True)
+        else:
+            df.reset_index(drop=True, inplace=True)
+        return df
+
+    @classmethod
+    @sentry_span
+    async def _fetch_release_events(cls,
+                                    repos: Sequence[str],
+                                    account: int,
+                                    meta_ids: Tuple[int, ...],
+                                    time_from: datetime,
+                                    time_to: datetime,
+                                    mdb: databases.Database,
+                                    rdb: databases.Database,
+                                    ) -> pd.DataFrame:
+        """Load pushed releases from persistentdata DB."""
+        if len(repos) == 0:
+            return dummy_releases_df()
+        release_rows = await mdb.fetch_all(
+            select([Repository.node_id, Repository.full_name])
+            .where(and_(
+                Repository.acc_id.in_(meta_ids),
+                Repository.full_name.in_(repos),
+            )))
+        repo_ids = {r[0]: r[1] for r in release_rows}
+        release_rows = await rdb.fetch_all(
+            select([ReleaseNotification])
+            .where(and_(
+                ReleaseNotification.account_id == account,
+                ReleaseNotification.published_at.between(time_from, time_to),
+                ReleaseNotification.repository_node_id.in_(repo_ids),
+            ))
+            .order_by(desc(ReleaseNotification.published_at)))
+        unresolved_commits_short = defaultdict(list)
+        unresolved_commits_long = defaultdict(list)
+        for row in release_rows:
+            if row[ReleaseNotification.resolved_commit_node_id.key] is None:
+                repo = row[ReleaseNotification.repository_node_id.key]
+                commit = row[ReleaseNotification.commit_hash_prefix.key]
+                if len(commit) == 7:
+                    unresolved_commits_short[repo].append(commit)
+                else:
+                    unresolved_commits_long[repo].append(commit)
+        author_node_ids = {r[ReleaseNotification.author_node_id.key]
+                           for r in release_rows} - {None}
+        queries = []
+        queries.extend(
+            select([PushCommit.repository_node_id, PushCommit.node_id, PushCommit.sha])
+            .where(and_(PushCommit.acc_id.in_(meta_ids),
+                        PushCommit.repository_node_id == repo,
+                        func.substr(PushCommit.sha, 1, 7).in_(commits)))
+            for repo, commits in unresolved_commits_short.items()
+        )
+        queries.extend(
+            select([PushCommit.repository_node_id, PushCommit.node_id, PushCommit.sha])
+            .where(and_(PushCommit.acc_id.in_(meta_ids),
+                        PushCommit.repository_node_id == repo,
+                        PushCommit.sha.in_(commits)))
+            for repo, commits in unresolved_commits_long.items()
+        )
+        if len(queries) == 1:
+            sql = queries[0]
+        elif len(queries) > 1:
+            sql = union_all(*queries)
+        else:
+            sql = None
+        resolved_commits = {}
+        user_map = {}
+        tasks = []
+        if sql is not None:
+            async def resolve_commits():
+                commit_rows = await mdb.fetch_all(sql)
+                for row in commit_rows:
+                    repo = row[PushCommit.repository_node_id.key]
+                    node_id = row[PushCommit.node_id.key]
+                    sha = row[PushCommit.sha.key]
+                    resolved_commits[(repo, sha)] = node_id, sha
+                    resolved_commits[(repo, sha[:7])] = node_id, sha
+
+            tasks.append(resolve_commits())
+        if author_node_ids:
+            async def resolve_users():
+                user_rows = await mdb.fetch_all(select([User.node_id, User.login])
+                                                .where(and_(User.acc_id.in_(meta_ids),
+                                                            User.node_id.in_(author_node_ids))))
+                nonlocal user_map
+                user_map = {r[User.node_id.key]: r[User.login.key] for r in user_rows}
+
+            tasks.append(resolve_users())
+        await gather(*tasks)
+
+        releases = []
+        updated = []
+        for row in release_rows:
+            repo = row[ReleaseNotification.repository_node_id.key]
+            if (commit_node_id := row[ReleaseNotification.resolved_commit_node_id.key]) is None:
+                commit_node_id, commit_hash = resolved_commits.get(
+                    (repo, commit_prefix := row[ReleaseNotification.commit_hash_prefix.key]),
+                    (None, None))
+                if commit_node_id is not None:
+                    updated.append((repo, commit_prefix, commit_node_id, commit_hash))
+                else:
+                    continue
+            else:
+                commit_hash = row[ReleaseNotification.resolved_commit_hash.key]
+            author = row[ReleaseNotification.author_node_id.key]
+            releases.append({
+                Release.author.key: user_map.get(author, author),
+                Release.commit_id.key: commit_node_id,
+                Release.id.key: commit_node_id,
+                Release.name.key: row[ReleaseNotification.name.key],
+                Release.published_at.key:
+                    row[ReleaseNotification.published_at.key].replace(tzinfo=timezone.utc),
+                Release.repository_full_name.key: repo_ids[repo],
+                Release.repository_node_id.key: repo,
+                Release.sha.key: commit_hash,
+                Release.tag.key: None,
+                Release.url.key: row[ReleaseNotification.url.key],
+                matched_by_column: ReleaseMatch.event.value,
+            })
+        if updated:
+            async def update_pushed_release_commits():
+                for repo, prefix, node_id, full_hash in updated:
+                    await rdb.execute(
+                        update(ReleaseNotification)
+                        .where(and_(ReleaseNotification.account_id == account,
+                                    ReleaseNotification.repository_node_id == repo,
+                                    ReleaseNotification.commit_hash_prefix == prefix))
+                        .values({
+                            ReleaseNotification.updated_at: datetime.now(timezone.utc),
+                            ReleaseNotification.resolved_commit_node_id: node_id,
+                            ReleaseNotification.resolved_commit_hash: full_hash,
+                        }))
+
+            await defer(update_pushed_release_commits(),
+                        "update_pushed_release_commits(%d)" % len(updated))
+        return pd.DataFrame(releases)
+
+    @classmethod
+    @sentry_span
+    async def _store_precomputed_release_match_spans(
+            cls,
+            match_groups: Dict[ReleaseMatch, Dict[str, List[str]]],
+            matched_bys: Dict[str, ReleaseMatch],
+            time_from: datetime,
+            time_to: datetime,
+            account: int,
+            pdb: databases.core.Connection) -> None:
+        assert isinstance(pdb, databases.core.Connection)
+        inserted = []
+        time_to = min(time_to, datetime.now(timezone.utc))
+        for rm, pair in match_groups.items():
+            if rm == ReleaseMatch.tag:
+                prefix = "tag|"
+            elif rm == ReleaseMatch.branch:
+                prefix = "branch|"
+            else:
+                raise AssertionError("Impossible release match: %s" % rm)
+            for val, repos in pair.items():
+                rms = prefix + val
+                for repo in repos:
+                    # Avoid inserting the span with branch releases if we release by tag
+                    # and the release settings are ambiguous. See DEV-1137.
+                    if rm == matched_bys[repo] or rm == ReleaseMatch.tag:
+                        inserted.append(GitHubReleaseMatchTimespan(
+                            acc_id=account,
+                            repository_full_name=repo,
+                            release_match=rms,
+                            time_from=time_from,
+                            time_to=time_to,
+                        ).explode(with_primary_keys=True))
+        if not inserted:
+            return
+        if isinstance(pdb.raw_connection, asyncpg.Connection):
+            sql = postgres_insert(GitHubReleaseMatchTimespan)
+            sql = sql.on_conflict_do_update(
+                constraint=GitHubReleaseMatchTimespan.__table__.primary_key,
+                set_={
+                    GitHubReleaseMatchTimespan.time_from.key: least(
+                        sql.excluded.time_from, GitHubReleaseMatchTimespan.time_from),
+                    GitHubReleaseMatchTimespan.time_to.key: greatest(
+                        sql.excluded.time_to, GitHubReleaseMatchTimespan.time_to),
+                },
+            )
+        else:
+            sql = insert(GitHubReleaseMatchTimespan).prefix_with("OR REPLACE")
+        with sentry_sdk.start_span(op="_store_precomputed_release_match_spans/execute_many"):
+            await pdb.execute_many(sql, inserted)
+
+    @classmethod
+    @sentry_span
+    async def _store_precomputed_releases(cls, releases: pd.DataFrame,
+                                          default_branches: Dict[str, str],
+                                          settings: ReleaseSettings,
+                                          account: int,
+                                          pdb: databases.core.Connection) -> None:
+        assert isinstance(pdb, databases.core.Connection)
+        if not isinstance(releases.index, pd.RangeIndex):
+            releases = releases.reset_index()
+        inserted = []
+        columns = [Release.id.key,
+                   Release.repository_full_name.key,
+                   Release.repository_node_id.key,
+                   Release.author.key,
+                   Release.name.key,
+                   Release.tag.key,
+                   Release.url.key,
+                   Release.sha.key,
+                   Release.commit_id.key,
+                   matched_by_column,
+                   Release.published_at.key]
+        for row in zip(*(releases[c].values for c in columns[:-1]),
+                       releases[Release.published_at.key]):
+            obj = {columns[i]: v for i, v in enumerate(row)}
+            obj[Release.acc_id.key] = account
+            repo = row[1]
+            if obj[matched_by_column] == ReleaseMatch.branch:
+                obj[PrecomputedRelease.release_match.key] = "branch|" + \
+                    settings.native[repo].branches.replace(
+                        default_branch_alias, default_branches[repo])
+            elif obj[matched_by_column] == ReleaseMatch.tag:
+                obj[PrecomputedRelease.release_match.key] = \
+                    "tag|" + settings.native[row[1]].tags
+            else:
+                raise AssertionError("Impossible release match: %s" % obj)
+            del obj[matched_by_column]
+            inserted.append(obj)
+
+        if inserted:
+            if isinstance(pdb.raw_connection, asyncpg.Connection):
+                sql = postgres_insert(PrecomputedRelease)
+                sql = sql.on_conflict_do_nothing()
+            else:
+                sql = insert(PrecomputedRelease).prefix_with("OR IGNORE")
+
+            with sentry_sdk.start_span(op="_store_precomputed_releases/execute_many"):
+                await pdb.execute_many(sql, inserted)
 
 
 def dummy_releases_df() -> pd.DataFrame:
@@ -374,481 +689,201 @@ def remove_ambigous_precomputed_releases(df: pd.DataFrame, repo_column: str) -> 
     return df
 
 
-@sentry_span
-async def _fetch_precomputed_releases(match_groups: Dict[ReleaseMatch, Dict[str, List[str]]],
-                                      time_from: datetime,
-                                      time_to: datetime,
-                                      account: int,
-                                      pdb: databases.Database,
-                                      index: Optional[Union[str, Sequence[str]]] = None,
-                                      ) -> pd.DataFrame:
-    prel = PrecomputedRelease
-    or_items, _ = match_groups_to_sql(match_groups, prel)
-    if pdb.url.dialect == "sqlite":
-        query = (
-            select([prel])
-            .where(and_(or_(*or_items) if or_items else false(),
-                        prel.published_at.between(time_from, time_to),
-                        prel.acc_id == account))
-            .order_by(desc(prel.published_at))
-        )
-    else:
-        query = union_all(*(
-            select([prel])
-            .where(and_(item,
-                        prel.published_at.between(time_from, time_to),
-                        prel.acc_id == account))
-            .order_by(desc(prel.published_at))
-            for item in or_items))
-    df = await read_sql_query(query, pdb, prel)
-    df = remove_ambigous_precomputed_releases(df, prel.repository_full_name.key)
-    if index is not None:
-        df.set_index(index, inplace=True)
-    else:
-        df.reset_index(drop=True, inplace=True)
-    return df
+@cached_methods
+class ReleaseMatcher:
+    """Release matcher for tag and branch."""
 
+    def __init__(self, account: int, meta_ids: Tuple[int, ...],
+                 mdb: databases.Database, pdb: databases.Database,
+                 cache: Optional[aiomcache.Client]):
+        """Create a `ReleaseMatcher`."""
+        self._account = account
+        self._meta_ids = meta_ids
+        self._mdb = mdb
+        self._pdb = pdb
+        self._cache = cache
 
-@sentry_span
-async def fetch_precomputed_release_match_spans(
-        match_groups: Dict[ReleaseMatch, Dict[str, List[str]]],
-        account: int,
-        pdb: databases.Database) -> Dict[str, Dict[str, Tuple[datetime, datetime]]]:
-    """Find out the precomputed time intervals for each release match group of repositories."""
-    ghrts = GitHubReleaseMatchTimespan
-    sqlite = pdb.url.dialect == "sqlite"
-    or_items, _ = match_groups_to_sql(match_groups, ghrts)
-    if pdb.url.dialect == "sqlite":
-        query = (
-            select([ghrts.repository_full_name, ghrts.release_match,
-                    ghrts.time_from, ghrts.time_to])
-            .where(and_(or_(*or_items), ghrts.acc_id == account))
-        )
-    else:
-        query = union_all(*(
-            select([ghrts.repository_full_name, ghrts.release_match,
-                    ghrts.time_from, ghrts.time_to])
-            .where(and_(item, ghrts.acc_id == account))
-            for item in or_items))
-    rows = await pdb.fetch_all(query)
-    spans = {}
-    for row in rows:
-        if row[ghrts.release_match.key].startswith("tag|"):
-            release_match = ReleaseMatch.tag
-        else:
-            release_match = ReleaseMatch.branch
-        times = row[ghrts.time_from.key], row[ghrts.time_to.key]
-        if sqlite:
-            times = tuple(t.replace(tzinfo=timezone.utc) for t in times)
-        spans.setdefault(row[ghrts.repository_full_name.key], {})[release_match] = times
-    return spans
-
-
-@sentry_span
-async def _store_precomputed_release_match_spans(
-        match_groups: Dict[ReleaseMatch, Dict[str, List[str]]],
-        matched_bys: Dict[str, ReleaseMatch],
-        time_from: datetime,
-        time_to: datetime,
-        account: int,
-        pdb: databases.core.Connection) -> None:
-    assert isinstance(pdb, databases.core.Connection)
-    inserted = []
-    time_to = min(time_to, datetime.now(timezone.utc))
-    for rm, pair in match_groups.items():
-        if rm == ReleaseMatch.tag:
-            prefix = "tag|"
-        elif rm == ReleaseMatch.branch:
-            prefix = "branch|"
-        else:
-            raise AssertionError("Impossible release match: %s" % rm)
-        for val, repos in pair.items():
-            rms = prefix + val
-            for repo in repos:
-                # Avoid inserting the span with branch releases if we release by tag
-                # and the release settings are ambiguous. See DEV-1137.
-                if rm == matched_bys[repo] or rm == ReleaseMatch.tag:
-                    inserted.append(GitHubReleaseMatchTimespan(
-                        acc_id=account,
-                        repository_full_name=repo,
-                        release_match=rms,
-                        time_from=time_from,
-                        time_to=time_to,
-                    ).explode(with_primary_keys=True))
-    if not inserted:
-        return
-    if isinstance(pdb.raw_connection, asyncpg.Connection):
-        sql = postgres_insert(GitHubReleaseMatchTimespan)
-        sql = sql.on_conflict_do_update(
-            constraint=GitHubReleaseMatchTimespan.__table__.primary_key,
-            set_={
-                GitHubReleaseMatchTimespan.time_from.key: least(
-                    sql.excluded.time_from, GitHubReleaseMatchTimespan.time_from),
-                GitHubReleaseMatchTimespan.time_to.key: greatest(
-                    sql.excluded.time_to, GitHubReleaseMatchTimespan.time_to),
-            },
-        )
-    else:
-        sql = insert(GitHubReleaseMatchTimespan).prefix_with("OR REPLACE")
-    with sentry_sdk.start_span(op="_store_precomputed_release_match_spans/execute_many"):
-        await pdb.execute_many(sql, inserted)
-
-
-@sentry_span
-async def _store_precomputed_releases(releases: pd.DataFrame,
-                                      default_branches: Dict[str, str],
-                                      settings: ReleaseSettings,
-                                      account: int,
-                                      pdb: databases.core.Connection) -> None:
-    assert isinstance(pdb, databases.core.Connection)
-    if not isinstance(releases.index, pd.RangeIndex):
-        releases = releases.reset_index()
-    inserted = []
-    columns = [Release.id.key,
-               Release.repository_full_name.key,
-               Release.repository_node_id.key,
-               Release.author.key,
-               Release.name.key,
-               Release.tag.key,
-               Release.url.key,
-               Release.sha.key,
-               Release.commit_id.key,
-               matched_by_column,
-               Release.published_at.key]
-    for row in zip(*(releases[c].values for c in columns[:-1]),
-                   releases[Release.published_at.key]):
-        obj = {columns[i]: v for i, v in enumerate(row)}
-        obj[Release.acc_id.key] = account
-        repo = row[1]
-        if obj[matched_by_column] == ReleaseMatch.branch:
-            obj[PrecomputedRelease.release_match.key] = "branch|" + \
-                settings.native[repo].branches.replace(
-                    default_branch_alias, default_branches[repo])
-        elif obj[matched_by_column] == ReleaseMatch.tag:
-            obj[PrecomputedRelease.release_match.key] = \
-                "tag|" + settings.native[row[1]].tags
-        else:
-            raise AssertionError("Impossible release match: %s" % obj)
-        del obj[matched_by_column]
-        inserted.append(obj)
-
-    if inserted:
-        if isinstance(pdb.raw_connection, asyncpg.Connection):
-            sql = postgres_insert(PrecomputedRelease)
-            sql = sql.on_conflict_do_nothing()
-        else:
-            sql = insert(PrecomputedRelease).prefix_with("OR IGNORE")
-
-        with sentry_sdk.start_span(op="_store_precomputed_releases/execute_many"):
-            await pdb.execute_many(sql, inserted)
-
-
-@sentry_span
-async def _fetch_release_events(repos: Sequence[str],
-                                account: int,
-                                meta_ids: Tuple[int, ...],
-                                time_from: datetime,
-                                time_to: datetime,
-                                mdb: databases.Database,
-                                rdb: databases.Database,
-                                ) -> pd.DataFrame:
-    """Load pushed releases from persistentdata DB."""
-    if len(repos) == 0:
-        return dummy_releases_df()
-    release_rows = await mdb.fetch_all(
-        select([Repository.node_id, Repository.full_name])
-        .where(and_(
-            Repository.acc_id.in_(meta_ids),
-            Repository.full_name.in_(repos),
-        )))
-    repo_ids = {r[0]: r[1] for r in release_rows}
-    release_rows = await rdb.fetch_all(
-        select([ReleaseNotification])
-        .where(and_(
-            ReleaseNotification.account_id == account,
-            ReleaseNotification.published_at.between(time_from, time_to),
-            ReleaseNotification.repository_node_id.in_(repo_ids),
-        ))
-        .order_by(desc(ReleaseNotification.published_at)))
-    unresolved_commits_short = defaultdict(list)
-    unresolved_commits_long = defaultdict(list)
-    for row in release_rows:
-        if row[ReleaseNotification.resolved_commit_node_id.key] is None:
-            repo = row[ReleaseNotification.repository_node_id.key]
-            commit = row[ReleaseNotification.commit_hash_prefix.key]
-            if len(commit) == 7:
-                unresolved_commits_short[repo].append(commit)
-            else:
-                unresolved_commits_long[repo].append(commit)
-    author_node_ids = {r[ReleaseNotification.author_node_id.key] for r in release_rows} - {None}
-    queries = []
-    queries.extend(
-        select([PushCommit.repository_node_id, PushCommit.node_id, PushCommit.sha])
-        .where(and_(PushCommit.acc_id.in_(meta_ids),
-                    PushCommit.repository_node_id == repo,
-                    func.substr(PushCommit.sha, 1, 7).in_(commits)))
-        for repo, commits in unresolved_commits_short.items()
-    )
-    queries.extend(
-        select([PushCommit.repository_node_id, PushCommit.node_id, PushCommit.sha])
-        .where(and_(PushCommit.acc_id.in_(meta_ids),
-                    PushCommit.repository_node_id == repo,
-                    PushCommit.sha.in_(commits)))
-        for repo, commits in unresolved_commits_long.items()
-    )
-    if len(queries) == 1:
-        sql = queries[0]
-    elif len(queries) > 1:
-        sql = union_all(*queries)
-    else:
-        sql = None
-    resolved_commits = {}
-    user_map = {}
-    tasks = []
-    if sql is not None:
-        async def resolve_commits():
-            commit_rows = await mdb.fetch_all(sql)
-            for row in commit_rows:
-                repo = row[PushCommit.repository_node_id.key]
-                node_id = row[PushCommit.node_id.key]
-                sha = row[PushCommit.sha.key]
-                resolved_commits[(repo, sha)] = node_id, sha
-                resolved_commits[(repo, sha[:7])] = node_id, sha
-
-        tasks.append(resolve_commits())
-    if author_node_ids:
-        async def resolve_users():
-            user_rows = await mdb.fetch_all(select([User.node_id, User.login])
-                                            .where(and_(User.acc_id.in_(meta_ids),
-                                                        User.node_id.in_(author_node_ids))))
-            nonlocal user_map
-            user_map = {r[User.node_id.key]: r[User.login.key] for r in user_rows}
-
-        tasks.append(resolve_users())
-    await gather(*tasks)
-
-    releases = []
-    updated = []
-    for row in release_rows:
-        repo = row[ReleaseNotification.repository_node_id.key]
-        if (commit_node_id := row[ReleaseNotification.resolved_commit_node_id.key]) is None:
-            commit_node_id, commit_hash = resolved_commits.get(
-                (repo, commit_prefix := row[ReleaseNotification.commit_hash_prefix.key]),
-                (None, None))
-            if commit_node_id is not None:
-                updated.append((repo, commit_prefix, commit_node_id, commit_hash))
-            else:
-                continue
-        else:
-            commit_hash = row[ReleaseNotification.resolved_commit_hash.key]
-        author = row[ReleaseNotification.author_node_id.key]
-        releases.append({
-            Release.author.key: user_map.get(author, author),
-            Release.commit_id.key: commit_node_id,
-            Release.id.key: commit_node_id,
-            Release.name.key: row[ReleaseNotification.name.key],
-            Release.published_at.key:
-                row[ReleaseNotification.published_at.key].replace(tzinfo=timezone.utc),
-            Release.repository_full_name.key: repo_ids[repo],
-            Release.repository_node_id.key: repo,
-            Release.sha.key: commit_hash,
-            Release.tag.key: None,
-            Release.url.key: row[ReleaseNotification.url.key],
-            matched_by_column: ReleaseMatch.event.value,
-        })
-    if updated:
-        async def update_pushed_release_commits():
-            for repo, prefix, node_id, full_hash in updated:
-                await rdb.execute(
-                    update(ReleaseNotification)
-                    .where(and_(ReleaseNotification.account_id == account,
-                                ReleaseNotification.repository_node_id == repo,
-                                ReleaseNotification.commit_hash_prefix == prefix))
-                    .values({
-                        ReleaseNotification.updated_at: datetime.now(timezone.utc),
-                        ReleaseNotification.resolved_commit_node_id: node_id,
-                        ReleaseNotification.resolved_commit_hash: full_hash,
-                    }))
-
-        await defer(update_pushed_release_commits(),
-                    "update_pushed_release_commits(%d)" % len(updated))
-    return pd.DataFrame(releases)
-
-
-@sentry_span
-async def _match_releases_by_tag(repos: Iterable[str],
-                                 time_from: datetime,
-                                 time_to: datetime,
-                                 settings: ReleaseSettings,
-                                 meta_ids: Tuple[int, ...],
-                                 mdb: databases.Database,
-                                 releases: Optional[pd.DataFrame] = None,
-                                 ) -> pd.DataFrame:
-    if releases is None:
-        with sentry_sdk.start_span(op="fetch_tags"):
-            releases = await read_sql_query(
-                select([Release])
-                .where(and_(Release.acc_id.in_(meta_ids),
-                            Release.published_at.between(time_from, time_to),
-                            Release.repository_full_name.in_(repos),
-                            Release.commit_id.isnot(None)))
-                .order_by(desc(Release.published_at)),
-                mdb, Release, index=[Release.repository_full_name.key, Release.tag.key])
-    releases = releases[~releases.index.duplicated(keep="first")]
-    if (missing_sha := releases[Release.sha.key].isnull().values).any():
-        raise ResponseError(NoSourceDataError(
-            detail="There are missing commit hashes for releases %s" %
-                   releases[Release.id.key].values[missing_sha].tolist()))
-    regexp_cache = {}
-    matched = []
-    for repo in repos:
-        try:
-            repo_releases = releases.loc[repo]
-        except KeyError:
-            continue
-        if repo_releases.empty:
-            continue
-        regexp = settings.native[repo].tags
-        if not regexp.endswith("$"):
-            regexp += "$"
-        # note: dict.setdefault() is not good here because re.compile() will be evaluated
-        try:
-            regexp = regexp_cache[regexp]
-        except KeyError:
-            regexp = regexp_cache[regexp] = re.compile(regexp)
-        tags_matched = repo_releases.index[repo_releases.index.str.match(regexp)]
-        matched.append([(repo, tag) for tag in tags_matched])
-    # this shows up in the profile but I cannot make it faster
-    releases = releases.loc[list(chain.from_iterable(matched))]
-    releases.reset_index(inplace=True)
-    releases[matched_by_column] = ReleaseMatch.tag.value
-    missing_names = releases[Release.name.key].isnull()
-    releases.loc[missing_names, Release.name.key] = releases.loc[missing_names, Release.tag.key]
-    return releases
-
-
-@sentry_span
-async def _match_releases_by_branch(repos: Iterable[str],
-                                    branches: pd.DataFrame,
-                                    default_branches: Dict[str, str],
+    @sentry_span
+    async def match_releases_by_tag(self,
+                                    repos: Iterable[str],
                                     time_from: datetime,
                                     time_to: datetime,
                                     settings: ReleaseSettings,
-                                    account: int,
-                                    meta_ids: Tuple[int, ...],
-                                    mdb: databases.Database,
-                                    pdb: databases.Database,
-                                    cache: Optional[aiomcache.Client],
-                                    ) -> pd.DataFrame:
-    branches = branches.take(np.where(branches[Branch.repository_full_name.key].isin(repos))[0])
-    branches_matched = _match_branches_by_release_settings(branches, default_branches, settings)
-    if not branches_matched:
-        return dummy_releases_df()
-    branches = pd.concat(branches_matched.values())
-    tasks = [
-        load_branch_commit_dates(branches, meta_ids, mdb),
-        fetch_precomputed_commit_history_dags(branches_matched, account, pdb, cache),
-    ]
-    _, dags = await gather(*tasks)
-    dags = await fetch_repository_commits(
-        dags, branches, BRANCH_FETCH_COMMITS_COLUMNS, False, account, meta_ids, mdb, pdb, cache)
-    first_shas = [
-        extract_first_parents(*dags[repo], branches[Branch.commit_sha.key].values.astype("S40"))
-        for repo, branches in branches_matched.items()
-    ]
-    first_shas = np.sort(np.concatenate(first_shas)).astype("U40")
-    first_commits = await _fetch_commits(first_shas, time_from, time_to, meta_ids, mdb, cache)
-    pseudo_releases = []
-    for repo in branches_matched:
-        commits = first_commits.take(
-            np.where(first_commits[PushCommit.repository_full_name.key] == repo)[0])
-        if commits.empty:
-            continue
-        gh_merge = ((commits[PushCommit.committer_name.key] == "GitHub")
-                    & (commits[PushCommit.committer_email.key] == "noreply@github.com"))
-        commits[PushCommit.author_login.key].where(
-            gh_merge, commits.loc[~gh_merge, PushCommit.committer_login.key], inplace=True)
-        pseudo_releases.append(pd.DataFrame({
-            Release.author.key: commits[PushCommit.author_login.key],
-            Release.commit_id.key: commits[PushCommit.node_id.key],
-            Release.id.key: commits[PushCommit.node_id.key],
-            Release.name.key: commits[PushCommit.sha.key],
-            Release.published_at.key: commits[PushCommit.committed_date.key],
-            Release.repository_full_name.key: repo,
-            Release.repository_node_id.key: commits[PushCommit.repository_node_id.key],
-            Release.sha.key: commits[PushCommit.sha.key],
-            Release.tag.key: None,
-            Release.url.key: commits[PushCommit.url.key],
-            Release.acc_id.key: commits[PushCommit.acc_id.key],
-            matched_by_column: [ReleaseMatch.branch.value] * len(commits),
-        }))
-    if not pseudo_releases:
-        return dummy_releases_df()
-    pseudo_releases = pd.concat(pseudo_releases, copy=False)
-    return pseudo_releases
+                                    releases: Optional[pd.DataFrame] = None) -> pd.DataFrame:
+        """Return the releases matched by tag."""
+        if releases is None:
+            with sentry_sdk.start_span(op="fetch_tags"):
+                releases = await read_sql_query(
+                    select([Release])
+                    .where(and_(Release.acc_id.in_(self._meta_ids),
+                                Release.published_at.between(time_from, time_to),
+                                Release.repository_full_name.in_(repos),
+                                Release.commit_id.isnot(None)))
+                    .order_by(desc(Release.published_at)),
+                    self._mdb, Release, index=[Release.repository_full_name.key, Release.tag.key])
+        releases = releases[~releases.index.duplicated(keep="first")]
+        if (missing_sha := releases[Release.sha.key].isnull().values).any():
+            raise ResponseError(NoSourceDataError(
+                detail="There are missing commit hashes for releases %s" %
+                       releases[Release.id.key].values[missing_sha].tolist()))
+        regexp_cache = {}
+        matched = []
+        for repo in repos:
+            try:
+                repo_releases = releases.loc[repo]
+            except KeyError:
+                continue
+            if repo_releases.empty:
+                continue
+            regexp = settings.native[repo].tags
+            if not regexp.endswith("$"):
+                regexp += "$"
+            # note: dict.setdefault() is not good here because re.compile() will be evaluated
+            try:
+                regexp = regexp_cache[regexp]
+            except KeyError:
+                regexp = regexp_cache[regexp] = re.compile(regexp)
+            tags_matched = repo_releases.index[repo_releases.index.str.match(regexp)]
+            matched.append([(repo, tag) for tag in tags_matched])
+        # this shows up in the profile but I cannot make it faster
+        releases = releases.loc[list(chain.from_iterable(matched))]
+        releases.reset_index(inplace=True)
+        releases[matched_by_column] = ReleaseMatch.tag.value
+        missing_names = releases[Release.name.key].isnull()
+        releases.loc[missing_names, Release.name.key] = releases.loc[missing_names,
+                                                                     Release.tag.key]
+        return releases
+
+    @sentry_span
+    async def match_releases_by_branch(self,
+                                       repos: Iterable[str],
+                                       branches: pd.DataFrame,
+                                       default_branches: Dict[str, str],
+                                       time_from: datetime,
+                                       time_to: datetime,
+                                       settings: ReleaseSettings) -> pd.DataFrame:
+        """Return the releases matched by branch."""
+        branches = branches.take(np.where(
+            branches[Branch.repository_full_name.key].isin(repos))[0])
+        branches_matched = self._match_branches_by_release_settings(
+            branches, default_branches, settings)
+        if not branches_matched:
+            return dummy_releases_df()
+        branches = pd.concat(branches_matched.values())
+        tasks = [
+            load_branch_commit_dates(branches, self._meta_ids, self._mdb),
+            fetch_precomputed_commit_history_dags(branches_matched, self._account,
+                                                  self._pdb, self._cache),
+        ]
+        _, dags = await gather(*tasks)
+        dags = await fetch_repository_commits(
+            dags, branches, BRANCH_FETCH_COMMITS_COLUMNS, False,
+            self._account, self._meta_ids, self._mdb, self._pdb, self._cache)
+        first_shas = [
+            extract_first_parents(
+                *dags[repo], branches[Branch.commit_sha.key].values.astype("S40"))
+            for repo, branches in branches_matched.items()
+        ]
+        first_shas = np.sort(np.concatenate(first_shas)).astype("U40")
+        first_commits = await self._fetch_commits(first_shas, time_from, time_to)
+        pseudo_releases = []
+        for repo in branches_matched:
+            commits = first_commits.take(
+                np.where(first_commits[PushCommit.repository_full_name.key] == repo)[0])
+            if commits.empty:
+                continue
+            gh_merge = ((commits[PushCommit.committer_name.key] == "GitHub")
+                        & (commits[PushCommit.committer_email.key] == "noreply@github.com"))
+            commits[PushCommit.author_login.key].where(
+                gh_merge, commits.loc[~gh_merge, PushCommit.committer_login.key], inplace=True)
+            pseudo_releases.append(pd.DataFrame({
+                Release.author.key: commits[PushCommit.author_login.key],
+                Release.commit_id.key: commits[PushCommit.node_id.key],
+                Release.id.key: commits[PushCommit.node_id.key],
+                Release.name.key: commits[PushCommit.sha.key],
+                Release.published_at.key: commits[PushCommit.committed_date.key],
+                Release.repository_full_name.key: repo,
+                Release.repository_node_id.key: commits[PushCommit.repository_node_id.key],
+                Release.sha.key: commits[PushCommit.sha.key],
+                Release.tag.key: None,
+                Release.url.key: commits[PushCommit.url.key],
+                Release.acc_id.key: commits[PushCommit.acc_id.key],
+                matched_by_column: [ReleaseMatch.branch.value] * len(commits),
+            }))
+        if not pseudo_releases:
+            return dummy_releases_df()
+        pseudo_releases = pd.concat(pseudo_releases, copy=False)
+        return pseudo_releases
+
+    def _match_branches_by_release_settings(self,
+                                            branches: pd.DataFrame,
+                                            default_branches: Dict[str, str],
+                                            settings: ReleaseSettings,
+                                            ) -> Dict[str, pd.DataFrame]:
+        branches_matched = {}
+        regexp_cache = {}
+        for repo, repo_branches in branches.groupby(Branch.repository_full_name.key, sort=False):
+            regexp = settings.native[repo].branches
+            default_branch = default_branches[repo]
+            regexp = regexp.replace(default_branch_alias, default_branch)
+            if not regexp.endswith("$"):
+                regexp += "$"
+            # note: dict.setdefault() is not good here because re.compile() will be evaluated
+            try:
+                regexp = regexp_cache[regexp]
+            except KeyError:
+                regexp = regexp_cache[regexp] = re.compile(regexp)
+            matched = repo_branches[repo_branches[Branch.branch_name.key].str.match(regexp)]
+            if not matched.empty:
+                branches_matched[repo] = matched
+        return branches_matched
+
+    @sentry_span
+    @cached(
+        exptime=60 * 60,  # 1 hour
+        serialize=pickle.dumps,
+        deserialize=pickle.loads,
+        # commit_shas are already sorted
+        key=lambda commit_shas, time_from, time_to, **_: (",".join(commit_shas),
+                                                          time_from, time_to),
+        refresh_on_access=True,
+        cache=lambda self, **_: self._cache,
+    )
+    async def _fetch_commits(self,
+                             commit_shas: Sequence[str],
+                             time_from: datetime,
+                             time_to: datetime) -> pd.DataFrame:
+        if (min(time_to, datetime.now(timezone.utc)) - time_from) > timedelta(hours=6):
+            query = \
+                select([PushCommit]) \
+                .where(and_(PushCommit.sha.in_(commit_shas),
+                            PushCommit.committed_date.between(time_from, time_to),
+                            PushCommit.acc_id.in_(self._meta_ids))) \
+                .order_by(desc(PushCommit.committed_date))
+        else:
+            # Postgres planner sucks in this case and we have to be inventive.
+            # Important: do not merge these two queries together using a nested JOIN or IN.
+            # The planner will go crazy and you'll end up with the wrong order of the filters.
+            rows = await self._mdb.fetch_all(
+                select([NodeCommit.id])
+                .where(and_(NodeCommit.oid.in_any_values(commit_shas),
+                            NodeCommit.acc_id.in_(self._meta_ids),
+                            NodeCommit.committed_date.between(time_from, time_to))))
+            if not rows:
+                return pd.DataFrame(columns=[c.key for c in PushCommit.__table__.columns])
+            ids = [r[0] for r in rows]
+            assert len(ids) <= len(commit_shas), len(ids)
+            query = \
+                select([PushCommit]) \
+                .where(and_(PushCommit.node_id.in_(ids),
+                            PushCommit.acc_id.in_(self._meta_ids))) \
+                .order_by(desc(PushCommit.committed_date))
+        return await read_sql_query(query, self._mdb, PushCommit)
 
 
-def _match_branches_by_release_settings(branches: pd.DataFrame,
-                                        default_branches: Dict[str, str],
-                                        settings: ReleaseSettings,
-                                        ) -> Dict[str, pd.DataFrame]:
-    branches_matched = {}
-    regexp_cache = {}
-    for repo, repo_branches in branches.groupby(Branch.repository_full_name.key, sort=False):
-        regexp = settings.native[repo].branches
-        default_branch = default_branches[repo]
-        regexp = regexp.replace(default_branch_alias, default_branch)
-        if not regexp.endswith("$"):
-            regexp += "$"
-        # note: dict.setdefault() is not good here because re.compile() will be evaluated
-        try:
-            regexp = regexp_cache[regexp]
-        except KeyError:
-            regexp = regexp_cache[regexp] = re.compile(regexp)
-        matched = repo_branches[repo_branches[Branch.branch_name.key].str.match(regexp)]
-        if not matched.empty:
-            branches_matched[repo] = matched
-    return branches_matched
-
-
-@sentry_span
-@cached(
-    exptime=60 * 60,  # 1 hour
-    serialize=pickle.dumps,
-    deserialize=pickle.loads,
-    # commit_shas are already sorted
-    key=lambda commit_shas, time_from, time_to, **_: (",".join(commit_shas), time_from, time_to),
-    refresh_on_access=True,
-)
-async def _fetch_commits(commit_shas: Sequence[str],
-                         time_from: datetime,
-                         time_to: datetime,
-                         meta_ids: Tuple[int, ...],
-                         mdb: databases.Database,
-                         cache: Optional[aiomcache.Client]) -> pd.DataFrame:
-    if (min(time_to, datetime.now(timezone.utc)) - time_from) > timedelta(hours=6):
-        query = \
-            select([PushCommit]) \
-            .where(and_(PushCommit.sha.in_(commit_shas),
-                        PushCommit.committed_date.between(time_from, time_to),
-                        PushCommit.acc_id.in_(meta_ids))) \
-            .order_by(desc(PushCommit.committed_date))
-    else:
-        # Postgres planner sucks in this case and we have to be inventive.
-        # Important: do not merge these two queries together using a nested JOIN or IN.
-        # The planner will go crazy and you'll end up with the wrong order of the filters.
-        rows = await mdb.fetch_all(
-            select([NodeCommit.id])
-            .where(and_(NodeCommit.oid.in_any_values(commit_shas),
-                        NodeCommit.acc_id.in_(meta_ids),
-                        NodeCommit.committed_date.between(time_from, time_to))))
-        if not rows:
-            return pd.DataFrame(columns=[c.key for c in PushCommit.__table__.columns])
-        ids = [r[0] for r in rows]
-        assert len(ids) <= len(commit_shas), len(ids)
-        query = \
-            select([PushCommit]) \
-            .where(and_(PushCommit.node_id.in_(ids),
-                        PushCommit.acc_id.in_(meta_ids))) \
-            .order_by(desc(PushCommit.committed_date))
-    return await read_sql_query(query, mdb, PushCommit)
+# TODO: these have to be removed, these are here just for keeping backward-compatibility
+# without the need to re-write already all the places these functions are called
+load_releases = ReleaseLoader.load_releases
+fetch_precomputed_release_match_spans = ReleaseLoader.fetch_precomputed_release_match_spans
+_fetch_precomputed_releases = ReleaseLoader._fetch_precomputed_releases
+_store_precomputed_release_match_spans = ReleaseLoader._store_precomputed_release_match_spans

--- a/server/athenian/api/controllers/miners/github/release_match.py
+++ b/server/athenian/api/controllers/miners/github/release_match.py
@@ -40,158 +40,6 @@ from athenian.api.models.precomputed.models import GitHubRepository
 from athenian.api.tracing import sentry_span
 
 
-@sentry_span
-async def map_prs_to_releases(prs: pd.DataFrame,
-                              releases: pd.DataFrame,
-                              matched_bys: Dict[str, ReleaseMatch],
-                              branches: pd.DataFrame,
-                              default_branches: Dict[str, str],
-                              time_to: datetime,
-                              dags: Dict[str, DAG],
-                              release_settings: ReleaseSettings,
-                              account: int,
-                              meta_ids: Tuple[int, ...],
-                              mdb: databases.Database,
-                              pdb: databases.Database,
-                              cache: Optional[aiomcache.Client],
-                              ) -> Tuple[pd.DataFrame,
-                                         Dict[str, Tuple[str, PullRequestFacts]],
-                                         asyncio.Event]:
-    """
-    Match the merged pull requests to the nearest releases that include them.
-
-    :return: 1. pd.DataFrame with the mapped PRs. \
-             2. Precomputed facts about unreleased merged PRs. \
-             3. Synchronization for updating the pdb table with merged unreleased PRs.
-    """
-    assert isinstance(time_to, datetime)
-    assert isinstance(mdb, databases.Database)
-    assert isinstance(pdb, databases.Database)
-    pr_releases = new_released_prs_df()
-    unreleased_prs_event = asyncio.Event()
-    if prs.empty:
-        unreleased_prs_event.set()
-        return pr_releases, {}, unreleased_prs_event
-    tasks = [
-        load_branch_commit_dates(branches, meta_ids, mdb),
-        load_merged_unreleased_pull_request_facts(
-            prs, nonemax(releases[Release.published_at.key].nonemax(), time_to),
-            LabelFilter.empty(), matched_bys, default_branches, release_settings,
-            account, pdb),
-        load_precomputed_pr_releases(
-            prs.index, time_to, matched_bys, default_branches, release_settings,
-            account, pdb, cache),
-    ]
-    _, unreleased_prs, precomputed_pr_releases = await gather(*tasks)
-    add_pdb_hits(pdb, "map_prs_to_releases/released", len(precomputed_pr_releases))
-    add_pdb_hits(pdb, "map_prs_to_releases/unreleased", len(unreleased_prs))
-    pr_releases = precomputed_pr_releases
-    merged_prs = prs[~prs.index.isin(pr_releases.index.union(unreleased_prs))]
-    if merged_prs.empty:
-        unreleased_prs_event.set()
-        return pr_releases, unreleased_prs, unreleased_prs_event
-    tasks = [
-        _fetch_labels(merged_prs.index, meta_ids, mdb),
-        _map_prs_to_releases(merged_prs, dags, releases),
-        _find_dead_merged_prs(merged_prs),
-    ]
-    labels, dead_prs, missed_released_prs = await gather(*tasks)
-    # PRs may wrongly classified as dead although they are really released; remove the conflicts
-    dead_prs.drop(index=missed_released_prs.index, inplace=True, errors="ignore")
-    add_pdb_misses(pdb, "map_prs_to_releases/released", len(missed_released_prs))
-    add_pdb_misses(pdb, "map_prs_to_releases/dead", len(dead_prs))
-    add_pdb_misses(pdb, "map_prs_to_releases/unreleased",
-                   len(merged_prs) - len(missed_released_prs) - len(dead_prs))
-    if not dead_prs.empty:
-        if not missed_released_prs.empty:
-            missed_released_prs = pd.concat([missed_released_prs, dead_prs])
-        else:
-            missed_released_prs = dead_prs
-    await defer(update_unreleased_prs(
-        merged_prs, missed_released_prs, time_to, labels, matched_bys, default_branches,
-        release_settings, account, pdb, unreleased_prs_event),
-        "update_unreleased_prs(%d, %d)" % (len(merged_prs), len(missed_released_prs)))
-    return pr_releases.append(missed_released_prs), unreleased_prs, unreleased_prs_event
-
-
-async def _map_prs_to_releases(prs: pd.DataFrame,
-                               dags: Dict[str, DAG],
-                               releases: pd.DataFrame,
-                               ) -> pd.DataFrame:
-    if prs.empty:
-        return new_released_prs_df()
-    releases = dict(list(releases.groupby(Release.repository_full_name.key, sort=False)))
-
-    released_prs = []
-    release_columns = [
-        c.key for c in (Release.published_at, Release.author, Release.url,
-                        Release.id, Release.repository_full_name)
-    ] + [matched_by_column]
-    log = logging.getLogger("%s.map_prs_to_releases" % metadata.__package__)
-    for repo, repo_prs in prs.groupby(PullRequest.repository_full_name.key, sort=False):
-        try:
-            repo_releases = releases[repo]
-        except KeyError:
-            # no releases exist for this repo
-            continue
-        repo_prs = repo_prs.take(np.where(~repo_prs[PullRequest.merge_commit_sha.key].isnull())[0])
-        hashes, vertexes, edges = dags[repo]
-        if len(hashes) == 0:
-            log.error("Very suspicious: empty DAG for %s\n%s", repo, repo_releases.to_csv())
-        ownership = mark_dag_access(
-            hashes, vertexes, edges, repo_releases[Release.sha.key].values.astype("S40"))
-        unmatched = np.where(ownership == len(repo_releases))[0]
-        if len(unmatched) > 0:
-            hashes = np.delete(hashes, unmatched)
-            ownership = np.delete(ownership, unmatched)
-        if len(hashes) == 0:
-            continue
-        merge_hashes = repo_prs[PullRequest.merge_commit_sha.key].values.astype("S40")
-        merges_found = searchsorted_inrange(hashes, merge_hashes)
-        found_mask = hashes[merges_found] == merge_hashes
-        found_releases = repo_releases[release_columns].take(ownership[merges_found[found_mask]])
-        if not found_releases.empty:
-            found_prs = repo_prs.index.take(np.nonzero(found_mask)[0])
-            found_releases.set_index(found_prs, inplace=True)
-            released_prs.append(found_releases)
-        await asyncio.sleep(0)
-    if released_prs:
-        released_prs = pd.concat(released_prs, copy=False)
-    else:
-        released_prs = new_released_prs_df()
-    released_prs[Release.published_at.key] = np.maximum(
-        released_prs[Release.published_at.key],
-        prs.loc[released_prs.index, PullRequest.merged_at.key])
-    return postprocess_datetime(released_prs)
-
-
-@sentry_span
-async def _find_dead_merged_prs(prs: pd.DataFrame) -> pd.DataFrame:
-    dead_indexes = np.nonzero(prs["dead"].values)[0]
-    dead_prs = [
-        (pr_id, None, None, None, None, repo, ReleaseMatch.force_push_drop)
-        for repo, pr_id in zip(prs[PullRequest.repository_full_name.key].take(dead_indexes).values,
-                               prs.index.take(dead_indexes).values)
-    ]
-    return new_released_prs_df(dead_prs)
-
-
-@sentry_span
-async def _fetch_labels(node_ids: Iterable[str],
-                        meta_ids: Tuple[int, ...],
-                        mdb: databases.Database,
-                        ) -> Dict[str, List[str]]:
-    rows = await mdb.fetch_all(
-        select([PullRequestLabel.pull_request_node_id, func.lower(PullRequestLabel.name)])
-        .where(and_(PullRequestLabel.pull_request_node_id.in_(node_ids),
-                    PullRequestLabel.acc_id.in_(meta_ids))))
-    labels = {}
-    for row in rows:
-        node_id, label = row[0], row[1]
-        labels.setdefault(node_id, []).append(label)
-    return labels
-
-
 async def load_commit_dags(releases: pd.DataFrame,
                            account: int,
                            meta_ids: Tuple[int, ...],
@@ -206,379 +54,571 @@ async def load_commit_dags(releases: pd.DataFrame,
         pdags, releases, RELEASE_FETCH_COMMITS_COLUMNS, False, account, meta_ids, mdb, pdb, cache)
 
 
-@sentry_span
-async def _find_old_released_prs(commits: np.ndarray,
-                                 repos: np.ndarray,
-                                 time_boundary: datetime,
-                                 authors: Collection[str],
-                                 mergers: Collection[str],
-                                 jira: JIRAFilter,
-                                 updated_min: Optional[datetime],
-                                 updated_max: Optional[datetime],
-                                 pr_blacklist: Optional[BinaryExpression],
-                                 pr_whitelist: Optional[BinaryExpression],
-                                 meta_ids: Tuple[int, ...],
-                                 mdb: databases.Database,
-                                 cache: Optional[aiomcache.Client],
-                                 ) -> pd.DataFrame:
-    assert len(commits) == len(repos)
-    assert len(commits) > 0
-    filters = [
-        PullRequest.merged_at < time_boundary,
-        PullRequest.hidden.is_(False),
-        PullRequest.acc_id.in_(meta_ids),
-        PullRequest.merge_commit_sha.in_(commits.astype("U40")),
-    ]
-    if updated_min is not None:
-        filters.append(PullRequest.updated_at.between(updated_min, updated_max))
-    if len(authors) and len(mergers):
-        filters.append(or_(
-            PullRequest.user_login.in_any_values(authors),
-            PullRequest.merged_by_login.in_any_values(mergers),
-        ))
-    elif len(authors):
-        filters.append(PullRequest.user_login.in_any_values(authors))
-    elif len(mergers):
-        filters.append(PullRequest.merged_by_login.in_any_values(mergers))
-    if pr_blacklist is not None:
-        filters.append(pr_blacklist)
-    if pr_whitelist is not None:
-        filters.append(pr_whitelist)
-    if not jira:
-        query = select([PullRequest]).where(and_(*filters))
-    else:
-        query = await generate_jira_prs_query(filters, jira, mdb, cache)
-    query = query.order_by(PullRequest.merge_commit_sha.key)
-    prs = await read_sql_query(query, mdb, PullRequest, index=PullRequest.node_id.key)
-    if prs.empty:
-        return prs
-    pr_commits = prs[PullRequest.merge_commit_sha.key].values.astype("S40")
-    pr_repos = prs[PullRequest.repository_full_name.key].values.astype("S")
-    indexes = np.searchsorted(commits, pr_commits)
-    checked = np.nonzero(pr_repos == repos[indexes])[0]
-    if len(checked) < len(prs):
-        prs = prs.take(checked)
-    return prs
+class PullRequestToReleaseMapper:
+    """Mapper from pull requests to releases."""
+
+    @classmethod
+    @sentry_span
+    async def map_prs_to_releases(cls,
+                                  prs: pd.DataFrame,
+                                  releases: pd.DataFrame,
+                                  matched_bys: Dict[str, ReleaseMatch],
+                                  branches: pd.DataFrame,
+                                  default_branches: Dict[str, str],
+                                  time_to: datetime,
+                                  dags: Dict[str, DAG],
+                                  release_settings: ReleaseSettings,
+                                  account: int,
+                                  meta_ids: Tuple[int, ...],
+                                  mdb: databases.Database,
+                                  pdb: databases.Database,
+                                  cache: Optional[aiomcache.Client],
+                                  ) -> Tuple[pd.DataFrame,
+                                             Dict[str, Tuple[str, PullRequestFacts]],
+                                             asyncio.Event]:
+        """
+        Match the merged pull requests to the nearest releases that include them.
+
+        :return: 1. pd.DataFrame with the mapped PRs. \
+                 2. Precomputed facts about unreleased merged PRs. \
+                 3. Synchronization for updating the pdb table with merged unreleased PRs.
+        """
+        assert isinstance(time_to, datetime)
+        assert isinstance(mdb, databases.Database)
+        assert isinstance(pdb, databases.Database)
+        pr_releases = new_released_prs_df()
+        unreleased_prs_event = asyncio.Event()
+        if prs.empty:
+            unreleased_prs_event.set()
+            return pr_releases, {}, unreleased_prs_event
+        tasks = [
+            load_branch_commit_dates(branches, meta_ids, mdb),
+            load_merged_unreleased_pull_request_facts(
+                prs, nonemax(releases[Release.published_at.key].nonemax(), time_to),
+                LabelFilter.empty(), matched_bys, default_branches, release_settings,
+                account, pdb),
+            load_precomputed_pr_releases(
+                prs.index, time_to, matched_bys, default_branches, release_settings,
+                account, pdb, cache),
+        ]
+        _, unreleased_prs, precomputed_pr_releases = await gather(*tasks)
+        add_pdb_hits(pdb, "map_prs_to_releases/released", len(precomputed_pr_releases))
+        add_pdb_hits(pdb, "map_prs_to_releases/unreleased", len(unreleased_prs))
+        pr_releases = precomputed_pr_releases
+        merged_prs = prs[~prs.index.isin(pr_releases.index.union(unreleased_prs))]
+        if merged_prs.empty:
+            unreleased_prs_event.set()
+            return pr_releases, unreleased_prs, unreleased_prs_event
+        tasks = [
+            cls._fetch_labels(merged_prs.index, meta_ids, mdb),
+            cls._map_prs_to_releases(merged_prs, dags, releases),
+            cls._find_dead_merged_prs(merged_prs),
+        ]
+        labels, dead_prs, missed_released_prs = await gather(*tasks)
+        # PRs may wrongly classified as dead although they are really released; remove
+        # the conflicts
+        dead_prs.drop(index=missed_released_prs.index, inplace=True, errors="ignore")
+        add_pdb_misses(pdb, "map_prs_to_releases/released", len(missed_released_prs))
+        add_pdb_misses(pdb, "map_prs_to_releases/dead", len(dead_prs))
+        add_pdb_misses(pdb, "map_prs_to_releases/unreleased",
+                       len(merged_prs) - len(missed_released_prs) - len(dead_prs))
+        if not dead_prs.empty:
+            if not missed_released_prs.empty:
+                missed_released_prs = pd.concat([missed_released_prs, dead_prs])
+            else:
+                missed_released_prs = dead_prs
+        await defer(update_unreleased_prs(
+            merged_prs, missed_released_prs, time_to, labels, matched_bys, default_branches,
+            release_settings, account, pdb, unreleased_prs_event),
+            "update_unreleased_prs(%d, %d)" % (len(merged_prs), len(missed_released_prs)))
+        return pr_releases.append(missed_released_prs), unreleased_prs, unreleased_prs_event
+
+    @classmethod
+    async def _map_prs_to_releases(cls,
+                                   prs: pd.DataFrame,
+                                   dags: Dict[str, DAG],
+                                   releases: pd.DataFrame,
+                                   ) -> pd.DataFrame:
+        if prs.empty:
+            return new_released_prs_df()
+        releases = dict(list(releases.groupby(Release.repository_full_name.key, sort=False)))
+
+        released_prs = []
+        release_columns = [
+            c.key for c in (Release.published_at, Release.author, Release.url,
+                            Release.id, Release.repository_full_name)
+        ] + [matched_by_column]
+        log = logging.getLogger("%s.map_prs_to_releases" % metadata.__package__)
+        for repo, repo_prs in prs.groupby(PullRequest.repository_full_name.key, sort=False):
+            try:
+                repo_releases = releases[repo]
+            except KeyError:
+                # no releases exist for this repo
+                continue
+            repo_prs = repo_prs.take(
+                np.where(~repo_prs[PullRequest.merge_commit_sha.key].isnull())[0])
+            hashes, vertexes, edges = dags[repo]
+            if len(hashes) == 0:
+                log.error("Very suspicious: empty DAG for %s\n%s", repo, repo_releases.to_csv())
+            ownership = mark_dag_access(
+                hashes, vertexes, edges, repo_releases[Release.sha.key].values.astype("S40"))
+            unmatched = np.where(ownership == len(repo_releases))[0]
+            if len(unmatched) > 0:
+                hashes = np.delete(hashes, unmatched)
+                ownership = np.delete(ownership, unmatched)
+            if len(hashes) == 0:
+                continue
+            merge_hashes = repo_prs[PullRequest.merge_commit_sha.key].values.astype("S40")
+            merges_found = searchsorted_inrange(hashes, merge_hashes)
+            found_mask = hashes[merges_found] == merge_hashes
+            found_releases = repo_releases[release_columns].take(
+                ownership[merges_found[found_mask]])
+            if not found_releases.empty:
+                found_prs = repo_prs.index.take(np.nonzero(found_mask)[0])
+                found_releases.set_index(found_prs, inplace=True)
+                released_prs.append(found_releases)
+            await asyncio.sleep(0)
+        if released_prs:
+            released_prs = pd.concat(released_prs, copy=False)
+        else:
+            released_prs = new_released_prs_df()
+        released_prs[Release.published_at.key] = np.maximum(
+            released_prs[Release.published_at.key],
+            prs.loc[released_prs.index, PullRequest.merged_at.key])
+        return postprocess_datetime(released_prs)
+
+    @classmethod
+    @sentry_span
+    async def _find_dead_merged_prs(cls, prs: pd.DataFrame) -> pd.DataFrame:
+        dead_indexes = np.nonzero(prs["dead"].values)[0]
+        dead_prs = [
+            (pr_id, None, None, None, None, repo, ReleaseMatch.force_push_drop)
+            for repo, pr_id in zip(
+                prs[PullRequest.repository_full_name.key].take(dead_indexes).values,
+                prs.index.take(dead_indexes).values)
+        ]
+        return new_released_prs_df(dead_prs)
+
+    @classmethod
+    @sentry_span
+    async def _fetch_labels(cls,
+                            node_ids: Iterable[str],
+                            meta_ids: Tuple[int, ...],
+                            mdb: databases.Database,
+                            ) -> Dict[str, List[str]]:
+        rows = await mdb.fetch_all(
+            select([PullRequestLabel.pull_request_node_id, func.lower(PullRequestLabel.name)])
+            .where(and_(PullRequestLabel.pull_request_node_id.in_(node_ids),
+                        PullRequestLabel.acc_id.in_(meta_ids))))
+        labels = {}
+        for row in rows:
+            node_id, label = row[0], row[1]
+            labels.setdefault(node_id, []).append(label)
+        return labels
 
 
-def _extract_released_commits(releases: pd.DataFrame,
-                              dag: DAG,
-                              time_boundary: datetime,
-                              ) -> np.ndarray:
-    time_mask = releases[Release.published_at.key] >= time_boundary
-    new_releases = releases.take(np.where(time_mask)[0])
-    assert not new_releases.empty, "you must check this before calling me"
-    hashes, vertexes, edges = dag
-    visited_hashes, _, _ = extract_subdag(
-        hashes, vertexes, edges, new_releases[Release.sha.key].values.astype("S40"))
-    # we need to traverse the DAG from *all* the previous releases because of release branches
-    if not time_mask.all():
-        boundary_release_hashes = releases[Release.sha.key].values[~time_mask].astype("S40")
-    else:
-        boundary_release_hashes = []
-    if len(boundary_release_hashes) == 0:
-        return visited_hashes
-    ignored_hashes, _, _ = extract_subdag(hashes, vertexes, edges, boundary_release_hashes)
-    deleted_indexes = np.searchsorted(visited_hashes, ignored_hashes)
-    # boundary_release_hash may touch some unique hashes not present in visited_hashes
-    deleted_indexes = deleted_indexes[deleted_indexes < len(visited_hashes)]
-    released_hashes = np.delete(visited_hashes, deleted_indexes)
-    return released_hashes
+# TODO: these have to be removed, these are here just for keeping backward-compatibility
+# without the need to re-write already all the places these functions are called
+map_prs_to_releases = PullRequestToReleaseMapper.map_prs_to_releases
 
 
-@sentry_span
-async def map_releases_to_prs(repos: Collection[str],
-                              branches: pd.DataFrame,
-                              default_branches: Dict[str, str],
-                              time_from: datetime,
-                              time_to: datetime,
-                              authors: Collection[str],
-                              mergers: Collection[str],
-                              jira: JIRAFilter,
-                              release_settings: ReleaseSettings,
-                              updated_min: Optional[datetime],
-                              updated_max: Optional[datetime],
-                              pdags: Optional[Dict[str, DAG]],
-                              account: int,
-                              meta_ids: Tuple[int, ...],
-                              mdb: databases.Database,
-                              pdb: databases.Database,
-                              rdb: databases.Database,
-                              cache: Optional[aiomcache.Client],
-                              pr_blacklist: Optional[BinaryExpression] = None,
-                              pr_whitelist: Optional[BinaryExpression] = None,
-                              truncate: bool = True,
-                              ) -> Tuple[pd.DataFrame,
-                                         pd.DataFrame,
-                                         Dict[str, ReleaseMatch],
-                                         Dict[str, DAG]]:
-    """Find pull requests which were released between `time_from` and `time_to` but merged before \
-    `time_from`.
+class ReleaseToPullRequestMapper:
+    """Mapper from releases to pull requests."""
 
-    :param authors: Required PR commit_authors.
-    :param mergers: Required PR mergers.
-    :param truncate: Do not load releases after `time_to`.
-    :return: pd.DataFrame with found PRs that were created before `time_from` and released \
-             between `time_from` and `time_to` \
-             + \
-             pd.DataFrame with the discovered releases between \
-             `time_from` and `time_to` (today if not `truncate`) \
-             + \
-             `matched_bys` so that we don't have to compute that mapping again. \
-             + \
-             commit DAGs that contain the relevant releases.
-    """
-    assert isinstance(time_from, datetime)
-    assert isinstance(time_to, datetime)
-    assert isinstance(mdb, databases.Database)
-    assert isinstance(pdb, databases.Database)
-    assert isinstance(pr_blacklist, (BinaryExpression, type(None)))
-    assert isinstance(pr_whitelist, (BinaryExpression, type(None)))
-    assert (updated_min is None) == (updated_max is None)
+    @classmethod
+    @sentry_span
+    async def map_releases_to_prs(cls,
+                                  repos: Collection[str],
+                                  branches: pd.DataFrame,
+                                  default_branches: Dict[str, str],
+                                  time_from: datetime,
+                                  time_to: datetime,
+                                  authors: Collection[str],
+                                  mergers: Collection[str],
+                                  jira: JIRAFilter,
+                                  release_settings: ReleaseSettings,
+                                  updated_min: Optional[datetime],
+                                  updated_max: Optional[datetime],
+                                  pdags: Optional[Dict[str, DAG]],
+                                  account: int,
+                                  meta_ids: Tuple[int, ...],
+                                  mdb: databases.Database,
+                                  pdb: databases.Database,
+                                  rdb: databases.Database,
+                                  cache: Optional[aiomcache.Client],
+                                  pr_blacklist: Optional[BinaryExpression] = None,
+                                  pr_whitelist: Optional[BinaryExpression] = None,
+                                  truncate: bool = True,
+                                  ) -> Tuple[pd.DataFrame,
+                                             pd.DataFrame,
+                                             Dict[str, ReleaseMatch],
+                                             Dict[str, DAG]]:
+        """Find pull requests which were released between `time_from` and `time_to` but merged before \
+        `time_from`.
 
-    async def fetch_pdags():
-        if pdags is None:
-            return await fetch_precomputed_commit_history_dags(repos, account, pdb, cache)
-        return pdags
+        :param authors: Required PR commit_authors.
+        :param mergers: Required PR mergers.
+        :param truncate: Do not load releases after `time_to`.
+        :return: pd.DataFrame with found PRs that were created before `time_from` and released \
+                 between `time_from` and `time_to` \
+                 + \
+                 pd.DataFrame with the discovered releases between \
+                 `time_from` and `time_to` (today if not `truncate`) \
+                 + \
+                 `matched_bys` so that we don't have to compute that mapping again. \
+                 + \
+                 commit DAGs that contain the relevant releases.
+        """
+        assert isinstance(time_from, datetime)
+        assert isinstance(time_to, datetime)
+        assert isinstance(mdb, databases.Database)
+        assert isinstance(pdb, databases.Database)
+        assert isinstance(pr_blacklist, (BinaryExpression, type(None)))
+        assert isinstance(pr_whitelist, (BinaryExpression, type(None)))
+        assert (updated_min is None) == (updated_max is None)
 
-    tasks = [
-        _find_releases_for_matching_prs(
-            repos, branches, default_branches, time_from, time_to, not truncate,
-            release_settings, account, meta_ids, mdb, pdb, rdb, cache),
-        fetch_pdags(),
-    ]
-    (matched_bys, releases, releases_in_time_range, release_settings), pdags = await gather(*tasks)
-    # ensure that our DAGs contain all the mentioned releases
-    rpak = Release.published_at.key
-    rrfnk = Release.repository_full_name.key
-    dags = await fetch_repository_commits(
-        pdags, releases, RELEASE_FETCH_COMMITS_COLUMNS, False, account, meta_ids, mdb, pdb, cache)
-    all_observed_repos = []
-    all_observed_commits = []
-    # find the released commit hashes by two DAG traversals
-    with sentry_sdk.start_span(op="_generate_released_prs_clause"):
-        for repo, repo_releases in releases.groupby(rrfnk, sort=False):
-            if (repo_releases[rpak] >= time_from).any():
-                observed_commits = _extract_released_commits(repo_releases, dags[repo], time_from)
-                if len(observed_commits):
-                    all_observed_commits.append(observed_commits)
-                    all_observed_repos.append(np.full(
-                        len(observed_commits), repo, dtype=f"S{len(repo)}"))
-    if all_observed_commits:
-        all_observed_repos = np.concatenate(all_observed_repos)
-        all_observed_commits = np.concatenate(all_observed_commits)
-        order = np.argsort(all_observed_commits)
-        all_observed_commits = all_observed_commits[order]
-        all_observed_repos = all_observed_repos[order]
-        prs = await _find_old_released_prs(
-            all_observed_commits, all_observed_repos, time_from, authors, mergers, jira,
-            updated_min, updated_max, pr_blacklist, pr_whitelist, meta_ids, mdb, cache)
-    else:
-        prs = pd.DataFrame(columns=[c.name for c in PullRequest.__table__.columns
-                                    if c.name != PullRequest.node_id.key])
-        prs.index = pd.Index([], name=PullRequest.node_id.key)
-    prs["dead"] = False
-    return prs, releases_in_time_range, matched_bys, dags
+        async def fetch_pdags():
+            if pdags is None:
+                return await fetch_precomputed_commit_history_dags(repos, account, pdb, cache)
+            return pdags
 
+        tasks = [
+            cls._find_releases_for_matching_prs(
+                repos, branches, default_branches, time_from, time_to, not truncate,
+                release_settings, account, meta_ids, mdb, pdb, rdb, cache),
+            fetch_pdags(),
+        ]
+        (matched_bys, releases, releases_in_time_range, release_settings), pdags = await gather(
+            *tasks)
+        # ensure that our DAGs contain all the mentioned releases
+        rpak = Release.published_at.key
+        rrfnk = Release.repository_full_name.key
+        dags = await fetch_repository_commits(
+            pdags, releases, RELEASE_FETCH_COMMITS_COLUMNS, False, account, meta_ids,
+            mdb, pdb, cache)
+        all_observed_repos = []
+        all_observed_commits = []
+        # find the released commit hashes by two DAG traversals
+        with sentry_sdk.start_span(op="_generate_released_prs_clause"):
+            for repo, repo_releases in releases.groupby(rrfnk, sort=False):
+                if (repo_releases[rpak] >= time_from).any():
+                    observed_commits = cls._extract_released_commits(
+                        repo_releases, dags[repo], time_from)
+                    if len(observed_commits):
+                        all_observed_commits.append(observed_commits)
+                        all_observed_repos.append(np.full(
+                            len(observed_commits), repo, dtype=f"S{len(repo)}"))
+        if all_observed_commits:
+            all_observed_repos = np.concatenate(all_observed_repos)
+            all_observed_commits = np.concatenate(all_observed_commits)
+            order = np.argsort(all_observed_commits)
+            all_observed_commits = all_observed_commits[order]
+            all_observed_repos = all_observed_repos[order]
+            prs = await cls._find_old_released_prs(
+                all_observed_commits, all_observed_repos, time_from, authors, mergers, jira,
+                updated_min, updated_max, pr_blacklist, pr_whitelist, meta_ids, mdb, cache)
+        else:
+            prs = pd.DataFrame(columns=[c.name for c in PullRequest.__table__.columns
+                                        if c.name != PullRequest.node_id.key])
+            prs.index = pd.Index([], name=PullRequest.node_id.key)
+        prs["dead"] = False
+        return prs, releases_in_time_range, matched_bys, dags
 
-@sentry_span
-async def _find_releases_for_matching_prs(repos: Iterable[str],
-                                          branches: pd.DataFrame,
-                                          default_branches: Dict[str, str],
-                                          time_from: datetime,
-                                          time_to: datetime,
-                                          until_today: bool,
-                                          release_settings: ReleaseSettings,
-                                          account: int,
-                                          meta_ids: Tuple[int, ...],
-                                          mdb: databases.Database,
-                                          pdb: databases.Database,
-                                          rdb: databases.Database,
-                                          cache: Optional[aiomcache.Client],
-                                          releases_in_time_range: Optional[pd.DataFrame] = None,
-                                          ) -> Tuple[Dict[str, ReleaseMatch],
-                                                     pd.DataFrame,
-                                                     pd.DataFrame,
-                                                     ReleaseSettings]:
-    """
-    Load releases with sufficient history depth.
+    @classmethod
+    @sentry_span
+    async def _find_releases_for_matching_prs(cls,
+                                              repos: Iterable[str],
+                                              branches: pd.DataFrame,
+                                              default_branches: Dict[str, str],
+                                              time_from: datetime,
+                                              time_to: datetime,
+                                              until_today: bool,
+                                              release_settings: ReleaseSettings,
+                                              account: int,
+                                              meta_ids: Tuple[int, ...],
+                                              mdb: databases.Database,
+                                              pdb: databases.Database,
+                                              rdb: databases.Database,
+                                              cache: Optional[aiomcache.Client],
+                                              releases_in_time_range: Optional[
+                                                  pd.DataFrame] = None,
+                                              ) -> Tuple[Dict[str, ReleaseMatch],
+                                                         pd.DataFrame,
+                                                         pd.DataFrame,
+                                                         ReleaseSettings]:
+        """
+        Load releases with sufficient history depth.
 
-    1. Load releases between `time_from` and `time_to`, record the effective release matches.
-    2. Use those matches to load enough releases before `time_from` to ensure we don't get \
-       "release leakages" in the commit DAG. Ideally, we should use the DAGs, but we take risks \
-       and just set a long enough lookbehind time interval.
-    3. Optionally, use those matches to load all the releases after `time_to`.
-    """
-    if releases_in_time_range is None:
-        # we have to load releases in two separate batches: before and after time_from
-        # that's because the release strategy can change depending on the time range
-        # see ENG-710 and ENG-725
-        releases_in_time_range, matched_bys = await load_releases(
-            repos, branches, default_branches, time_from, time_to,
-            release_settings, account, meta_ids, mdb, pdb, rdb, cache)
-    else:
-        matched_bys = {}
-    # these matching rules must be applied in the past to stay consistent
-    consistent_release_settings = release_settings.copy()
-    repos_matched_by_tag = []
-    repos_matched_by_branch = []
-    for repo in repos:
-        setting = release_settings.native[repo]
-        match = ReleaseMatch(matched_bys.setdefault(repo, setting.match))
-        consistent_release_settings.set_by_native(repo, ReleaseMatchSetting(
-            tags=setting.tags,
-            branches=setting.branches,
-            match=match,
-        ))
-        if match in (ReleaseMatch.tag, ReleaseMatch.event):
-            repos_matched_by_tag.append(repo)
-        elif match == ReleaseMatch.branch:
-            repos_matched_by_branch.append(repo)
+        1. Load releases between `time_from` and `time_to`, record the effective release matches.
+        2. Use those matches to load enough releases before `time_from` to ensure we don't get \
+           "release leakages" in the commit DAG. Ideally, we should use the DAGs, but we take \
+           risks and just set a long enough lookbehind time interval.
+        3. Optionally, use those matches to load all the releases after `time_to`.
+        """
+        if releases_in_time_range is None:
+            # we have to load releases in two separate batches: before and after time_from
+            # that's because the release strategy can change depending on the time range
+            # see ENG-710 and ENG-725
+            releases_in_time_range, matched_bys = await load_releases(
+                repos, branches, default_branches, time_from, time_to,
+                release_settings, account, meta_ids, mdb, pdb, rdb, cache)
+        else:
+            matched_bys = {}
+        # these matching rules must be applied in the past to stay consistent
+        consistent_release_settings = release_settings.copy()
+        repos_matched_by_tag = []
+        repos_matched_by_branch = []
+        for repo in repos:
+            setting = release_settings.native[repo]
+            match = ReleaseMatch(matched_bys.setdefault(repo, setting.match))
+            consistent_release_settings.set_by_native(repo, ReleaseMatchSetting(
+                tags=setting.tags,
+                branches=setting.branches,
+                match=match,
+            ))
+            if match in (ReleaseMatch.tag, ReleaseMatch.event):
+                repos_matched_by_tag.append(repo)
+            elif match == ReleaseMatch.branch:
+                repos_matched_by_branch.append(repo)
 
-    async def dummy_load_releases_until_today() -> Tuple[pd.DataFrame, Any]:
-        return dummy_releases_df(), None
+        async def dummy_load_releases_until_today() -> Tuple[pd.DataFrame, Any]:
+            return dummy_releases_df(), None
 
-    until_today_task = None
-    if until_today:
-        today = datetime.combine((datetime.now(timezone.utc) + timedelta(days=1)).date(),
-                                 datetime.min.time(), tzinfo=timezone.utc)
-        if today > time_to:
-            until_today_task = load_releases(
-                repos, branches, default_branches, time_to, today,
-                consistent_release_settings, account, meta_ids, mdb, pdb, rdb, cache)
-    if until_today_task is None:
-        until_today_task = dummy_load_releases_until_today()
-
-    # there are two groups of repos now: matched by tag and by branch
-    # we have to fetch *all* the tags from the past because:
-    # some repos fork a new branch for each release and make a unique release commit
-    # some repos maintain several major versions in parallel
-    # so when somebody releases 1.1.0 in August 2020 alongside with 2.0.0 released in June 2020
-    # and 1.0.0 in September 2018, we must load 1.0.0, otherwise the PR for 1.0.0 release
-    # will be matched to 1.1.0 in August 2020 and will have a HUGE release time
-
-    # we are golden if we match by branch, one older merge preceding `time_from` should be fine
-    # unless there are several release branches; we hope for the best then
-    # so we split repos and take two different logic paths
-
-    # find branch releases not older than 5 weeks before `time_from`
-    branch_lookbehind_time_from = time_from - timedelta(days=5 * 7)
-    # find tag releases not older than 2 years before `time_from`
-    tag_lookbehind_time_from = time_from - timedelta(days=2 * 365)
-    tasks = [
-        until_today_task,
-        load_releases(repos_matched_by_branch, branches, default_branches,
-                      branch_lookbehind_time_from, time_from, consistent_release_settings,
-                      account, meta_ids, mdb, pdb, rdb, cache),
-        load_releases(repos_matched_by_tag, branches, default_branches,
-                      tag_lookbehind_time_from, time_from, consistent_release_settings,
-                      account, meta_ids, mdb, pdb, rdb, cache),
-        _fetch_repository_first_commit_dates(repos_matched_by_branch, account, meta_ids,
-                                             mdb, pdb, cache),
-    ]
-    releases_today, releases_old_branches, releases_old_tags, repo_births = await gather(*tasks)
-    releases_today = releases_today[0]
-    releases_old_branches = releases_old_branches[0]
-    releases_old_tags = releases_old_tags[0]
-    hard_repos = set(repos_matched_by_branch) - \
-        set(releases_old_branches[Release.repository_full_name.key].unique())
-    if hard_repos:
-        with sentry_sdk.start_span(op="_find_releases_for_matching_prs/hard_repos"):
-            repo_births = sorted((v, k) for k, v in repo_births.items() if k in hard_repos)
-            repo_births_dates = [rb[0].replace(tzinfo=timezone.utc) for rb in repo_births]
-            repo_births_names = [rb[1] for rb in repo_births]
-            del repo_births
-            deeper_step = timedelta(days=6 * 31)
-            while hard_repos:
-                # no previous releases were discovered for `hard_repos`, go deeper in history
-                hard_repos = hard_repos.intersection(repo_births_names[:bisect.bisect_right(
-                    repo_births_dates, branch_lookbehind_time_from)])
-                if not hard_repos:
-                    break
-                extra_releases, _ = await load_releases(
-                    hard_repos, branches, default_branches,
-                    branch_lookbehind_time_from - deeper_step, branch_lookbehind_time_from,
+        until_today_task = None
+        if until_today:
+            today = datetime.combine((datetime.now(timezone.utc) + timedelta(days=1)).date(),
+                                     datetime.min.time(), tzinfo=timezone.utc)
+            if today > time_to:
+                until_today_task = load_releases(
+                    repos, branches, default_branches, time_to, today,
                     consistent_release_settings, account, meta_ids, mdb, pdb, rdb, cache)
-                releases_old_branches = releases_old_branches.append(extra_releases)
-                hard_repos -= set(extra_releases[Release.repository_full_name.key].unique())
-                del extra_releases
-                branch_lookbehind_time_from -= deeper_step
-                deeper_step *= 2
-    releases = pd.concat([releases_today, releases_in_time_range,
-                          releases_old_branches, releases_old_tags],
-                         ignore_index=True, copy=False)
-    releases.sort_values(Release.published_at.key,
-                         inplace=True, ascending=False, ignore_index=True)
-    if not releases_today.empty:
-        releases_in_time_range = pd.concat([releases_today, releases_in_time_range],
-                                           ignore_index=True, copy=False)
-    return matched_bys, releases, releases_in_time_range, consistent_release_settings
+        if until_today_task is None:
+            until_today_task = dummy_load_releases_until_today()
+
+        # there are two groups of repos now: matched by tag and by branch
+        # we have to fetch *all* the tags from the past because:
+        # some repos fork a new branch for each release and make a unique release commit
+        # some repos maintain several major versions in parallel
+        # so when somebody releases 1.1.0 in August 2020 alongside with 2.0.0 released in June 2020
+        # and 1.0.0 in September 2018, we must load 1.0.0, otherwise the PR for 1.0.0 release
+        # will be matched to 1.1.0 in August 2020 and will have a HUGE release time
+
+        # we are golden if we match by branch, one older merge preceding `time_from` should be fine
+        # unless there are several release branches; we hope for the best then
+        # so we split repos and take two different logic paths
+
+        # find branch releases not older than 5 weeks before `time_from`
+        branch_lookbehind_time_from = time_from - timedelta(days=5 * 7)
+        # find tag releases not older than 2 years before `time_from`
+        tag_lookbehind_time_from = time_from - timedelta(days=2 * 365)
+        tasks = [
+            until_today_task,
+            load_releases(repos_matched_by_branch, branches, default_branches,
+                          branch_lookbehind_time_from, time_from, consistent_release_settings,
+                          account, meta_ids, mdb, pdb, rdb, cache),
+            load_releases(repos_matched_by_tag, branches, default_branches,
+                          tag_lookbehind_time_from, time_from, consistent_release_settings,
+                          account, meta_ids, mdb, pdb, rdb, cache),
+            cls._fetch_repository_first_commit_dates(repos_matched_by_branch, account, meta_ids,
+                                                     mdb, pdb, cache),
+        ]
+        releases_today, releases_old_branches, releases_old_tags, repo_births = await gather(
+            *tasks)
+        releases_today = releases_today[0]
+        releases_old_branches = releases_old_branches[0]
+        releases_old_tags = releases_old_tags[0]
+        hard_repos = set(repos_matched_by_branch) - \
+            set(releases_old_branches[Release.repository_full_name.key].unique())
+        if hard_repos:
+            with sentry_sdk.start_span(op="_find_releases_for_matching_prs/hard_repos"):
+                repo_births = sorted((v, k) for k, v in repo_births.items() if k in hard_repos)
+                repo_births_dates = [rb[0].replace(tzinfo=timezone.utc) for rb in repo_births]
+                repo_births_names = [rb[1] for rb in repo_births]
+                del repo_births
+                deeper_step = timedelta(days=6 * 31)
+                while hard_repos:
+                    # no previous releases were discovered for `hard_repos`, go deeper in history
+                    hard_repos = hard_repos.intersection(repo_births_names[:bisect.bisect_right(
+                        repo_births_dates, branch_lookbehind_time_from)])
+                    if not hard_repos:
+                        break
+                    extra_releases, _ = await load_releases(
+                        hard_repos, branches, default_branches,
+                        branch_lookbehind_time_from - deeper_step, branch_lookbehind_time_from,
+                        consistent_release_settings, account, meta_ids, mdb, pdb, rdb, cache)
+                    releases_old_branches = releases_old_branches.append(extra_releases)
+                    hard_repos -= set(extra_releases[Release.repository_full_name.key].unique())
+                    del extra_releases
+                    branch_lookbehind_time_from -= deeper_step
+                    deeper_step *= 2
+        releases = pd.concat([releases_today, releases_in_time_range,
+                              releases_old_branches, releases_old_tags],
+                             ignore_index=True, copy=False)
+        releases.sort_values(Release.published_at.key,
+                             inplace=True, ascending=False, ignore_index=True)
+        if not releases_today.empty:
+            releases_in_time_range = pd.concat([releases_today, releases_in_time_range],
+                                               ignore_index=True, copy=False)
+        return matched_bys, releases, releases_in_time_range, consistent_release_settings
+
+    @classmethod
+    @sentry_span
+    async def _find_old_released_prs(cls,
+                                     commits: np.ndarray,
+                                     repos: np.ndarray,
+                                     time_boundary: datetime,
+                                     authors: Collection[str],
+                                     mergers: Collection[str],
+                                     jira: JIRAFilter,
+                                     updated_min: Optional[datetime],
+                                     updated_max: Optional[datetime],
+                                     pr_blacklist: Optional[BinaryExpression],
+                                     pr_whitelist: Optional[BinaryExpression],
+                                     meta_ids: Tuple[int, ...],
+                                     mdb: databases.Database,
+                                     cache: Optional[aiomcache.Client],
+                                     ) -> pd.DataFrame:
+        assert len(commits) == len(repos)
+        assert len(commits) > 0
+        filters = [
+            PullRequest.merged_at < time_boundary,
+            PullRequest.hidden.is_(False),
+            PullRequest.acc_id.in_(meta_ids),
+            PullRequest.merge_commit_sha.in_(commits.astype("U40")),
+        ]
+        if updated_min is not None:
+            filters.append(PullRequest.updated_at.between(updated_min, updated_max))
+        if len(authors) and len(mergers):
+            filters.append(or_(
+                PullRequest.user_login.in_any_values(authors),
+                PullRequest.merged_by_login.in_any_values(mergers),
+            ))
+        elif len(authors):
+            filters.append(PullRequest.user_login.in_any_values(authors))
+        elif len(mergers):
+            filters.append(PullRequest.merged_by_login.in_any_values(mergers))
+        if pr_blacklist is not None:
+            filters.append(pr_blacklist)
+        if pr_whitelist is not None:
+            filters.append(pr_whitelist)
+        if not jira:
+            query = select([PullRequest]).where(and_(*filters))
+        else:
+            query = await generate_jira_prs_query(filters, jira, mdb, cache)
+        query = query.order_by(PullRequest.merge_commit_sha.key)
+        prs = await read_sql_query(query, mdb, PullRequest, index=PullRequest.node_id.key)
+        if prs.empty:
+            return prs
+        pr_commits = prs[PullRequest.merge_commit_sha.key].values.astype("S40")
+        pr_repos = prs[PullRequest.repository_full_name.key].values.astype("S")
+        indexes = np.searchsorted(commits, pr_commits)
+        checked = np.nonzero(pr_repos == repos[indexes])[0]
+        if len(checked) < len(prs):
+            prs = prs.take(checked)
+        return prs
+
+    @classmethod
+    @sentry_span
+    @cached(
+        exptime=24 * 60 * 60,  # 1 day
+        serialize=pickle.dumps,
+        deserialize=pickle.loads,
+        key=lambda repos, **_: (",".join(sorted(repos)),),
+        refresh_on_access=True,
+    )
+    async def _fetch_repository_first_commit_dates(cls,
+                                                   repos: Iterable[str],
+                                                   account: int,
+                                                   meta_ids: Tuple[int, ...],
+                                                   mdb: databases.Database,
+                                                   pdb: databases.Database,
+                                                   cache: Optional[aiomcache.Client],
+                                                   ) -> Dict[str, datetime]:
+        rows = await pdb.fetch_all(
+            select([GitHubRepository.repository_full_name,
+                    GitHubRepository.first_commit.label("min")])
+            .where(and_(GitHubRepository.repository_full_name.in_(repos),
+                        GitHubRepository.acc_id == account)))
+        add_pdb_hits(pdb, "_fetch_repository_first_commit_dates", len(rows))
+        missing = set(repos) - {r[0] for r in rows}
+        add_pdb_misses(pdb, "_fetch_repository_first_commit_dates", len(missing))
+        if missing:
+            computed = await mdb.fetch_all(
+                select([func.min(NodeRepository.name_with_owner)
+                        .label(PushCommit.repository_full_name.key),
+                        func.min(NodeCommit.committed_date).label("min"),
+                        NodeRepository.id])
+                .select_from(join(NodeCommit, NodeRepository,
+                                  and_(NodeCommit.repository == NodeRepository.id,
+                                       NodeCommit.acc_id == NodeRepository.acc_id)))
+                .where(and_(NodeRepository.name_with_owner.in_(missing),
+                            NodeRepository.acc_id.in_(meta_ids)))
+                .group_by(NodeRepository.id))
+            if computed:
+                values = [
+                    GitHubRepository(
+                        acc_id=account,
+                        repository_full_name=r[0],
+                        first_commit=r[1],
+                        node_id=r[2],
+                    ).create_defaults().explode(with_primary_keys=True)
+                    for r in computed
+                ]
+                if mdb.url.dialect == "sqlite":
+                    for v in values:
+                        v[GitHubRepository.first_commit.key] = \
+                            v[GitHubRepository.first_commit.key].replace(tzinfo=timezone.utc)
+
+                async def insert_repository():
+                    async with pdb.connection() as pdb_conn:
+                        async with pdb_conn.transaction():
+                            try:
+                                await pdb_conn.execute_many(insert(GitHubRepository), values)
+                            except Exception as e:
+                                log = logging.getLogger(
+                                    "%s._fetch_repository_first_commit_dates" %
+                                    metadata.__package__)
+                                log.warning("Failed to store %d rows: %s: %s",
+                                            len(values), type(e).__name__, e)
+                await defer(insert_repository(), "insert_repository")
+                rows.extend(computed)
+        result = {r[0]: r[1] for r in rows}
+        if mdb.url.dialect == "sqlite" or pdb.url.dialect == "sqlite":
+            for k, v in result.items():
+                result[k] = v.replace(tzinfo=timezone.utc)
+        return result
+
+    @classmethod
+    def _extract_released_commits(cls,
+                                  releases: pd.DataFrame,
+                                  dag: DAG,
+                                  time_boundary: datetime,
+                                  ) -> np.ndarray:
+        time_mask = releases[Release.published_at.key] >= time_boundary
+        new_releases = releases.take(np.where(time_mask)[0])
+        assert not new_releases.empty, "you must check this before calling me"
+        hashes, vertexes, edges = dag
+        visited_hashes, _, _ = extract_subdag(
+            hashes, vertexes, edges, new_releases[Release.sha.key].values.astype("S40"))
+        # we need to traverse the DAG from *all* the previous releases because of release branches
+        if not time_mask.all():
+            boundary_release_hashes = releases[Release.sha.key].values[~time_mask].astype("S40")
+        else:
+            boundary_release_hashes = []
+        if len(boundary_release_hashes) == 0:
+            return visited_hashes
+        ignored_hashes, _, _ = extract_subdag(hashes, vertexes, edges, boundary_release_hashes)
+        deleted_indexes = np.searchsorted(visited_hashes, ignored_hashes)
+        # boundary_release_hash may touch some unique hashes not present in visited_hashes
+        deleted_indexes = deleted_indexes[deleted_indexes < len(visited_hashes)]
+        released_hashes = np.delete(visited_hashes, deleted_indexes)
+        return released_hashes
 
 
-@sentry_span
-@cached(
-    exptime=24 * 60 * 60,  # 1 day
-    serialize=pickle.dumps,
-    deserialize=pickle.loads,
-    key=lambda repos, **_: (",".join(sorted(repos)),),
-    refresh_on_access=True,
-)
-async def _fetch_repository_first_commit_dates(repos: Iterable[str],
-                                               account: int,
-                                               meta_ids: Tuple[int, ...],
-                                               mdb: databases.Database,
-                                               pdb: databases.Database,
-                                               cache: Optional[aiomcache.Client],
-                                               ) -> Dict[str, datetime]:
-    rows = await pdb.fetch_all(
-        select([GitHubRepository.repository_full_name,
-                GitHubRepository.first_commit.label("min")])
-        .where(and_(GitHubRepository.repository_full_name.in_(repos),
-                    GitHubRepository.acc_id == account)))
-    add_pdb_hits(pdb, "_fetch_repository_first_commit_dates", len(rows))
-    missing = set(repos) - {r[0] for r in rows}
-    add_pdb_misses(pdb, "_fetch_repository_first_commit_dates", len(missing))
-    if missing:
-        computed = await mdb.fetch_all(
-            select([func.min(NodeRepository.name_with_owner)
-                    .label(PushCommit.repository_full_name.key),
-                    func.min(NodeCommit.committed_date).label("min"),
-                    NodeRepository.id])
-            .select_from(join(NodeCommit, NodeRepository,
-                              and_(NodeCommit.repository == NodeRepository.id,
-                                   NodeCommit.acc_id == NodeRepository.acc_id)))
-            .where(and_(NodeRepository.name_with_owner.in_(missing),
-                        NodeRepository.acc_id.in_(meta_ids)))
-            .group_by(NodeRepository.id))
-        if computed:
-            values = [
-                GitHubRepository(
-                    acc_id=account,
-                    repository_full_name=r[0],
-                    first_commit=r[1],
-                    node_id=r[2],
-                ).create_defaults().explode(with_primary_keys=True)
-                for r in computed
-            ]
-            if mdb.url.dialect == "sqlite":
-                for v in values:
-                    v[GitHubRepository.first_commit.key] = \
-                        v[GitHubRepository.first_commit.key].replace(tzinfo=timezone.utc)
-
-            async def insert_repository():
-                async with pdb.connection() as pdb_conn:
-                    async with pdb_conn.transaction():
-                        try:
-                            await pdb_conn.execute_many(insert(GitHubRepository), values)
-                        except Exception as e:
-                            log = logging.getLogger(
-                                "%s._fetch_repository_first_commit_dates" % metadata.__package__)
-                            log.warning("Failed to store %d rows: %s: %s",
-                                        len(values), type(e).__name__, e)
-            await defer(insert_repository(), "insert_repository")
-            rows.extend(computed)
-    result = {r[0]: r[1] for r in rows}
-    if mdb.url.dialect == "sqlite" or pdb.url.dialect == "sqlite":
-        for k, v in result.items():
-            result[k] = v.replace(tzinfo=timezone.utc)
-    return result
+# TODO: these have to be removed, these are here just for keeping backward-compatibility
+# without the need to re-write already all the places these functions are called
+map_releases_to_prs = ReleaseToPullRequestMapper.map_releases_to_prs
+_fetch_repository_first_commit_dates = \
+    ReleaseToPullRequestMapper._fetch_repository_first_commit_dates
+_find_releases_for_matching_prs = ReleaseToPullRequestMapper._find_releases_for_matching_prs
+_find_dead_merged_prs = PullRequestToReleaseMapper._find_dead_merged_prs


### PR DESCRIPTION
This PR is a preparatory one to be able to work on [DEV-2148](https://athenianco.atlassian.net/browse/DEV-2148).

The idea is the same as we did for the PR miner: I grouped functions into classes in modules `athenian.api.controllers.miners.github.{release_match,release_load}` so that they can be extended for preloading.

I'd rathered open a separate PR since this is already a pretty big one despite being mostly moving things and changing callers.
