### PR TITLE
Preload precomputed release

### DIFF
--- a/server/athenian/api/controllers/features/entries.py
+++ b/server/athenian/api/controllers/features/entries.py
@@ -31,7 +31,7 @@ from athenian.api.controllers.features.github.pull_request_metrics import \
 from athenian.api.controllers.features.github.release_metrics import \
     group_releases_by_participants, merge_release_participants, ReleaseBinnedMetricCalculator
 from athenian.api.controllers.features.github.unfresh_pull_request_metrics import \
-    fetch_pull_request_facts_unfresh
+    UnfreshPullRequestFactsFetcher
 from athenian.api.controllers.features.histogram import HistogramParameters
 from athenian.api.controllers.features.metric_calculator import df_from_structs, group_by_repo, \
     group_to_indexes
@@ -78,6 +78,7 @@ class MetricEntriesCalculator:
     """Calculator for different metrics."""
 
     miner = PullRequestMiner
+    unfresh_pr_facts_fetcher = UnfreshPullRequestFactsFetcher
 
     def __init__(self, account: int, meta_ids: Tuple[int, ...],
                  mdb: Database, pdb: Database, rdb: Database,
@@ -555,7 +556,7 @@ class MetricEntriesCalculator:
                 or
                 len(participants.get(prpk.AUTHOR, [])) > unfresh_participants_threshold) and \
                 not fresh and not (participants.keys() - {prpk.AUTHOR, prpk.MERGER}):
-            facts = await fetch_pull_request_facts_unfresh(
+            facts = await self.unfresh_pr_facts_fetcher.fetch_pull_request_facts_unfresh(
                 self.miner, precomputed_facts, ambiguous, time_from, time_to, repositories,
                 participants, labels, jira, exclude_inactive, branches,
                 default_branches, release_settings, self._account, self._meta_ids,

--- a/server/athenian/api/controllers/features/github/unfresh_pull_request_metrics.py
+++ b/server/athenian/api/controllers/features/github/unfresh_pull_request_metrics.py
@@ -12,7 +12,7 @@ from athenian.api.controllers.miners.github.precomputed_prs import \
     discover_inactive_merged_unreleased_prs, load_merged_unreleased_pull_request_facts, \
     load_open_pull_request_facts_unfresh, remove_ambiguous_prs
 from athenian.api.controllers.miners.github.pull_request import PullRequestMiner
-from athenian.api.controllers.miners.github.release_load import load_releases
+from athenian.api.controllers.miners.github.release_load import ReleaseLoader
 from athenian.api.controllers.miners.jira.issue import generate_jira_prs_query
 from athenian.api.controllers.miners.types import PRParticipants, PullRequestFacts
 from athenian.api.controllers.settings import ReleaseSettings
@@ -23,6 +23,8 @@ from athenian.api.tracing import sentry_span
 
 class UnfreshPullRequestFactsFetcher:
     """Fetcher for unfreshed pull requests facts."""
+
+    release_loader = ReleaseLoader
 
     @classmethod
     @sentry_span
@@ -60,7 +62,7 @@ class UnfreshPullRequestFactsFetcher:
         tasks = [
             # map_releases_to_prs is not required because such PRs are already released,
             # by definition
-            load_releases(
+            cls.release_loader.load_releases(
                 repositories, branches, default_branches, time_from, time_to,
                 release_settings, account, meta_ids, mdb, pdb, rdb, cache),
             miner.fetch_prs(

--- a/server/athenian/api/controllers/features/github/unfresh_pull_request_metrics.py
+++ b/server/athenian/api/controllers/features/github/unfresh_pull_request_metrics.py
@@ -21,133 +21,148 @@ from athenian.api.models.metadata.github import PullRequest
 from athenian.api.tracing import sentry_span
 
 
-@sentry_span
-async def fetch_pull_request_facts_unfresh(miner: PullRequestMiner,
-                                           done_facts: Dict[str, PullRequestFacts],
-                                           ambiguous: Dict[str, List[str]],
-                                           time_from: datetime,
-                                           time_to: datetime,
-                                           repositories: Set[str],
-                                           participants: PRParticipants,
-                                           labels: LabelFilter,
-                                           jira: JIRAFilter,
-                                           exclude_inactive: bool,
-                                           branches: pd.DataFrame,
-                                           default_branches: Dict[str, str],
-                                           release_settings: ReleaseSettings,
-                                           account: int,
-                                           meta_ids: Tuple[int, ...],
-                                           mdb: databases.Database,
-                                           pdb: databases.Database,
-                                           rdb: databases.Database,
-                                           cache: Optional[aiomcache.Client],
-                                           ) -> Dict[str, PullRequestFacts]:
-    """
-    Load the missing facts about merged unreleased and open PRs from pdb instead of querying \
-    the most up to date information from mdb.
+class UnfreshPullRequestFactsFetcher:
+    """Fetcher for unfreshed pull requests facts."""
 
-    The major complexity here is to comply to all the filters.
+    @classmethod
+    @sentry_span
+    async def fetch_pull_request_facts_unfresh(cls,
+                                               miner: PullRequestMiner,
+                                               done_facts: Dict[str, PullRequestFacts],
+                                               ambiguous: Dict[str, List[str]],
+                                               time_from: datetime,
+                                               time_to: datetime,
+                                               repositories: Set[str],
+                                               participants: PRParticipants,
+                                               labels: LabelFilter,
+                                               jira: JIRAFilter,
+                                               exclude_inactive: bool,
+                                               branches: pd.DataFrame,
+                                               default_branches: Dict[str, str],
+                                               release_settings: ReleaseSettings,
+                                               account: int,
+                                               meta_ids: Tuple[int, ...],
+                                               mdb: databases.Database,
+                                               pdb: databases.Database,
+                                               rdb: databases.Database,
+                                               cache: Optional[aiomcache.Client],
+                                               ) -> Dict[str, PullRequestFacts]:
+        """
+        Load the missing facts about merged unreleased and open PRs from pdb instead of querying \
+        the most up to date information from mdb.
 
-    :return: Map from PR node IDs to their facts.
-    """
-    add_pdb_hits(pdb, "fresh", 1)
-    blacklist = PullRequest.node_id.notin_any_values(done_facts)
-    tasks = [
-        # map_releases_to_prs is not required because such PRs are already released, by definition
-        load_releases(
-            repositories, branches, default_branches, time_from, time_to,
-            release_settings, account, meta_ids, mdb, pdb, rdb, cache),
-        miner.fetch_prs(
-            time_from, time_to, repositories, participants, labels, jira, exclude_inactive,
-            blacklist, None, branches, None, account, meta_ids, mdb, pdb, cache, columns=[
-                PullRequest.node_id, PullRequest.repository_full_name, PullRequest.merged_at,
-                PullRequest.user_login,
-            ]),
-    ]
-    if jira and done_facts:
-        tasks.append(_filter_done_facts_jira(miner, done_facts, jira, meta_ids, mdb, cache))
-    else:
-        async def identity():
-            return done_facts
+        The major complexity here is to comply to all the filters.
 
-        tasks.append(identity())
-    if not exclude_inactive:
-        tasks.append(_fetch_inactive_merged_unreleased_prs(
-            time_from, time_to, repositories, participants, labels, jira, default_branches,
-            release_settings, account, meta_ids, mdb, pdb, cache))
-    else:
-        async def dummy_inactive_prs():
-            return pd.DataFrame()
+        :return: Map from PR node IDs to their facts.
+        """
+        add_pdb_hits(pdb, "fresh", 1)
+        blacklist = PullRequest.node_id.notin_any_values(done_facts)
+        tasks = [
+            # map_releases_to_prs is not required because such PRs are already released,
+            # by definition
+            load_releases(
+                repositories, branches, default_branches, time_from, time_to,
+                release_settings, account, meta_ids, mdb, pdb, rdb, cache),
+            miner.fetch_prs(
+                time_from, time_to, repositories, participants, labels, jira, exclude_inactive,
+                blacklist, None, branches, None, account, meta_ids, mdb, pdb, cache, columns=[
+                    PullRequest.node_id, PullRequest.repository_full_name, PullRequest.merged_at,
+                    PullRequest.user_login,
+                ]),
+        ]
+        if jira and done_facts:
+            tasks.append(cls._filter_done_facts_jira(miner, done_facts, jira, meta_ids, mdb,
+                                                     cache))
+        else:
+            async def identity():
+                return done_facts
 
-        tasks.append(dummy_inactive_prs())
-    (releases, matched_bys), (unreleased_prs, _), done_facts, inactive_merged_prs = await gather(
-        *tasks, op="discover PRs")
-    add_pdb_misses(pdb, "load_precomputed_done_facts_filters/ambiguous",
-                   remove_ambiguous_prs(done_facts, ambiguous, matched_bys))
-    unreleased_pr_node_ids = unreleased_prs.index.values
-    merged_mask = unreleased_prs[PullRequest.merged_at.key].notnull().values
-    open_prs = unreleased_pr_node_ids[~merged_mask]
-    open_pr_authors = dict(zip(
-        open_prs, unreleased_prs[PullRequest.user_login.key].values[~merged_mask]))
-    merged_prs = \
-        unreleased_prs[[PullRequest.repository_full_name.key]].take(np.where(merged_mask)[0])
-    if not inactive_merged_prs.empty:
-        merged_prs = pd.concat([merged_prs, inactive_merged_prs])
-    tasks = [
-        load_open_pull_request_facts_unfresh(
-            open_prs, time_from, time_to, exclude_inactive, open_pr_authors, account, pdb),
-        # require `checked_until` to be after `time_to` or now() - 1 hour (heater interval)
-        load_merged_unreleased_pull_request_facts(
-            merged_prs, min(time_to, datetime.now(timezone.utc) - timedelta(hours=1)),
-            LabelFilter.empty(), matched_bys,
-            default_branches, release_settings, account, pdb,
-            time_from=time_from, exclude_inactive=exclude_inactive),
-    ]
-    open_facts, merged_facts = await gather(*tasks)
-    add_pdb_hits(pdb, "precomputed_open_facts", len(open_facts))
-    add_pdb_hits(pdb, "precomputed_merged_unreleased_facts", len(merged_facts))
-    # ensure the priority order
-    return {**open_facts, **merged_facts, **done_facts}
+            tasks.append(identity())
+        if not exclude_inactive:
+            tasks.append(cls._fetch_inactive_merged_unreleased_prs(
+                time_from, time_to, repositories, participants, labels, jira, default_branches,
+                release_settings, account, meta_ids, mdb, pdb, cache))
+        else:
+            async def dummy_inactive_prs():
+                return pd.DataFrame()
+
+            tasks.append(dummy_inactive_prs())
+        (releases, matched_bys), (unreleased_prs, _), done_facts, inactive_merged_prs = \
+            await gather(*tasks, op="discover PRs")
+        add_pdb_misses(pdb, "load_precomputed_done_facts_filters/ambiguous",
+                       remove_ambiguous_prs(done_facts, ambiguous, matched_bys))
+        unreleased_pr_node_ids = unreleased_prs.index.values
+        merged_mask = unreleased_prs[PullRequest.merged_at.key].notnull().values
+        open_prs = unreleased_pr_node_ids[~merged_mask]
+        open_pr_authors = dict(zip(
+            open_prs, unreleased_prs[PullRequest.user_login.key].values[~merged_mask]))
+        merged_prs = \
+            unreleased_prs[[PullRequest.repository_full_name.key]].take(np.where(merged_mask)[0])
+        if not inactive_merged_prs.empty:
+            merged_prs = pd.concat([merged_prs, inactive_merged_prs])
+        tasks = [
+            load_open_pull_request_facts_unfresh(
+                open_prs, time_from, time_to, exclude_inactive, open_pr_authors, account, pdb),
+            # require `checked_until` to be after `time_to` or now() - 1 hour (heater interval)
+            load_merged_unreleased_pull_request_facts(
+                merged_prs, min(time_to, datetime.now(timezone.utc) - timedelta(hours=1)),
+                LabelFilter.empty(), matched_bys,
+                default_branches, release_settings, account, pdb,
+                time_from=time_from, exclude_inactive=exclude_inactive),
+        ]
+        open_facts, merged_facts = await gather(*tasks)
+        add_pdb_hits(pdb, "precomputed_open_facts", len(open_facts))
+        add_pdb_hits(pdb, "precomputed_merged_unreleased_facts", len(merged_facts))
+        # ensure the priority order
+        return {**open_facts, **merged_facts, **done_facts}
+
+    @classmethod
+    @sentry_span
+    async def _filter_done_facts_jira(cls,
+                                      miner: PullRequestMiner,
+                                      done_facts: Dict[str, PullRequestFacts],
+                                      jira: JIRAFilter,
+                                      meta_ids: Tuple[int, ...],
+                                      mdb: databases.Database,
+                                      cache: Optional[aiomcache.Client],
+                                      ) -> Dict[str, PullRequestFacts]:
+        filtered = await miner.filter_jira(
+            done_facts, jira, meta_ids, mdb, cache, columns=[PullRequest.node_id])
+        return {k: done_facts[k] for k in filtered.index.values}
+
+    @classmethod
+    @sentry_span
+    async def _fetch_inactive_merged_unreleased_prs(cls,
+                                                    time_from: datetime,
+                                                    time_to: datetime,
+                                                    repos: Set[str],
+                                                    participants: PRParticipants,
+                                                    labels: LabelFilter,
+                                                    jira: JIRAFilter,
+                                                    default_branches: Dict[str, str],
+                                                    release_settings: ReleaseSettings,
+                                                    account: int,
+                                                    meta_ids: Tuple[int, ...],
+                                                    mdb: databases.Database,
+                                                    pdb: databases.Database,
+                                                    cache: Optional[aiomcache.Client],
+                                                    ) -> pd.DataFrame:
+        node_ids, repos = await discover_inactive_merged_unreleased_prs(
+            time_from, time_to, repos, participants, labels, default_branches, release_settings,
+            account, pdb, cache)
+        if not jira:
+            df = pd.DataFrame.from_dict({PullRequest.node_id.key: node_ids,
+                                         PullRequest.repository_full_name.key: repos})
+            df.set_index(PullRequest.node_id.key, inplace=True)
+            return df
+        columns = [PullRequest.node_id, PullRequest.repository_full_name]
+        query = await generate_jira_prs_query(
+            [PullRequest.node_id.in_(node_ids), PullRequest.acc_id.in_(meta_ids)],
+            jira, mdb, cache, columns=columns)
+        return await read_sql_query(query, mdb, columns, index=PullRequest.node_id.key)
 
 
-@sentry_span
-async def _filter_done_facts_jira(miner: PullRequestMiner,
-                                  done_facts: Dict[str, PullRequestFacts],
-                                  jira: JIRAFilter,
-                                  meta_ids: Tuple[int, ...],
-                                  mdb: databases.Database,
-                                  cache: Optional[aiomcache.Client],
-                                  ) -> Dict[str, PullRequestFacts]:
-    filtered = await miner.filter_jira(
-        done_facts, jira, meta_ids, mdb, cache, columns=[PullRequest.node_id])
-    return {k: done_facts[k] for k in filtered.index.values}
-
-
-@sentry_span
-async def _fetch_inactive_merged_unreleased_prs(time_from: datetime,
-                                                time_to: datetime,
-                                                repos: Set[str],
-                                                participants: PRParticipants,
-                                                labels: LabelFilter,
-                                                jira: JIRAFilter,
-                                                default_branches: Dict[str, str],
-                                                release_settings: ReleaseSettings,
-                                                account: int,
-                                                meta_ids: Tuple[int, ...],
-                                                mdb: databases.Database,
-                                                pdb: databases.Database,
-                                                cache: Optional[aiomcache.Client],
-                                                ) -> pd.DataFrame:
-    node_ids, repos = await discover_inactive_merged_unreleased_prs(
-        time_from, time_to, repos, participants, labels, default_branches, release_settings,
-        account, pdb, cache)
-    if not jira:
-        df = pd.DataFrame.from_dict({PullRequest.node_id.key: node_ids,
-                                     PullRequest.repository_full_name.key: repos})
-        df.set_index(PullRequest.node_id.key, inplace=True)
-        return df
-    columns = [PullRequest.node_id, PullRequest.repository_full_name]
-    query = await generate_jira_prs_query(
-        [PullRequest.node_id.in_(node_ids), PullRequest.acc_id.in_(meta_ids)],
-        jira, mdb, cache, columns=columns)
-    return await read_sql_query(query, mdb, columns, index=PullRequest.node_id.key)
+# TODO: these have to be removed, these are here just for keeping backward-compatibility
+# without the need to re-write already all the places these functions are called
+fetch_pull_request_facts_unfresh = \
+    UnfreshPullRequestFactsFetcher.fetch_pull_request_facts_unfresh

--- a/server/athenian/api/experiments/preloading/entries.py
+++ b/server/athenian/api/experiments/preloading/entries.py
@@ -200,7 +200,7 @@ class PullRequestMiner(OriginalPullRequestMiner):
 
         if remove_acc_id:
             del prs[PullRequest.acc_id.key]
-        if PullRequest.closed.key in df:
+        if PullRequest.closed.key in prs:
             cls.adjust_pr_closed_merged_timestamps(prs)
 
         return prs

--- a/server/athenian/api/preloading/cache.py
+++ b/server/athenian/api/preloading/cache.py
@@ -10,6 +10,7 @@ from sqlalchemy import select
 from athenian.api import metadata
 from athenian.api.async_utils import gather, read_sql_query
 from athenian.api.models.metadata.github import PullRequest
+from athenian.api.models.precomputed.models import GitHubRelease as PrecomputedRelease
 from athenian.api.typing_utils import DatabaseLike
 
 
@@ -307,6 +308,21 @@ def get_memory_cache_options() -> Dict[str, Dict]:
                     PullRequest.node_id,
                     PullRequest.merge_commit_id,
                     PullRequest.merge_commit_sha,
+                ],
+            },
+        },
+        "pdb": {
+            "releases": {
+                "cols": [
+                    PrecomputedRelease.release_match,
+                    PrecomputedRelease.repository_full_name,
+                    PrecomputedRelease.published_at,
+                    PrecomputedRelease.acc_id,
+                ],
+                "categorical_cols": [
+                    PrecomputedRelease.acc_id,
+                    PrecomputedRelease.repository_full_name,
+                    PrecomputedRelease.release_match,
                 ],
             },
         },

--- a/server/athenian/api/preloading/cache.py
+++ b/server/athenian/api/preloading/cache.py
@@ -101,7 +101,7 @@ class CachedDataFrame:
     def filter(
         self,
         mask: pd.Series,
-        columns: Optional[Collection[str]],
+        columns: Optional[Collection[str]] = None,
         index: Optional[str] = None,
         uncast: bool = True,
     ) -> pd.DataFrame:


### PR DESCRIPTION
Closes [DEV-2148](https://athenianco.atlassian.net/browse/DEV-2148).

Tested with the following:
```
hey \
  -H 'Connection: keep-alive' \
  -H 'Pragma: no-cache' \
  -H 'Cache-Control: no-cache' \
  -H 'sec-ch-ua: "Google Chrome";v="89", "Chromium";v="89", ";Not A Brand";v="99"' \
  -H 'Accept: application/json' \
  -H 'Authorization: Bearer <evicted>' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_2_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36' \
  -H 'Content-Type: application/json' \
  -H 'Origin: http://localhost:3000' \
  -H 'Sec-Fetch-Site: same-site' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Referer: http://localhost:3000/' \
  -H 'Accept-Language: en-US,en;q=0.9,it-IT;q=0.8,it;q=0.7' \
  -m POST \
  -d '{"for":[{"repositories":["github.com/athenianco/athenian-api","github.com/athenianco/athenian-owl","github.com/athenianco/athenian-push-api","github.com/athenianco/athenian-webapp","github.com/athenianco/automation","github.com/athenianco/browser-extensions","github.com/athenianco/ci","github.com/athenianco/cloud-common","github.com/athenianco/environments","github.com/athenianco/helm-repo","github.com/athenianco/infrastructure","github.com/athenianco/metadata","github.com/athenianco/names-matcher","github.com/athenianco/pgbouncer-rr-patch","github.com/athenianco/precomputer","github.com/athenianco/reposet-sync"],"repogroups":[[0],[1],[2],[3],[4],[5],[6],[7],[8],[9],[10],[11],[12],[13],[14],[15]],"with":{"author":["github.com/vmarkovtsev","github.com/apps/dependabot","github.com/apps/dependabot-preview","github.com/gkwillie","github.com/snyk-bot","github.com/akbarik","github.com/dennwc","github.com/dpordomingo","github.com/lwsanty","github.com/se7entyse7en","github.com/znegrin","github.com/eiso","github.com/ibot3","github.com/marnovo","github.com/rrickay","github.com/warenlg"]}}],"metrics":["pr-wip-time","pr-wip-count","pr-wip-count-q","pr-review-time","pr-review-count","pr-review-count-q","pr-merging-time","pr-merging-count","pr-merging-count-q","pr-release-time","pr-release-count","pr-release-count-q","pr-lead-time","pr-lead-count","pr-lead-count-q","pr-cycle-time","pr-cycle-count","pr-cycle-count-q","pr-all-count","pr-wait-first-review-time","pr-wait-first-review-count","pr-wait-first-review-count-q","pr-flow-ratio","pr-opened","pr-reviewed","pr-not-reviewed","pr-merged","pr-rejected","pr-closed","pr-done","pr-size","pr-median-size","pr-wip-pending-count","pr-review-pending-count","pr-merging-pending-count","pr-release-pending-count","pr-opened-mapped-to-jira","pr-done-mapped-to-jira","pr-all-mapped-to-jira","pr-participants-per","pr-review-comments-per","pr-reviews-per"],"date_from":"2020-05-06","date_to":"2021-05-06","granularities":["all"],"exclude_inactive":true,"account":1,"timezone":120,"quantiles":[0,0.95]}' \
  -n 10 -c 1 -t 0 'http://localhost:8080/v1/metrics/prs'
```

# With preloading

```
Summary:
  Total:	11.5875 secs
  Slowest:	1.8847 secs
  Fastest:	0.9786 secs
  Average:	1.1587 secs
  Requests/sec:	0.8630


Response time histogram:
  0.979 [1]	|■■■■■■■■■■
  1.069 [4]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  1.160 [2]	|■■■■■■■■■■■■■■■■■■■■
  1.250 [2]	|■■■■■■■■■■■■■■■■■■■■
  1.341 [0]	|
  1.432 [0]	|
  1.522 [0]	|
  1.613 [0]	|
  1.703 [0]	|
  1.794 [0]	|
  1.885 [1]	|■■■■■■■■■■


Latency distribution:
  10% in 0.9919 secs
  25% in 1.0550 secs
  50% in 1.0788 secs
  75% in 1.2130 secs
  90% in 1.8847 secs
  0% in 0.0000 secs
  0% in 0.0000 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0005 secs, 0.9786 secs, 1.8847 secs
  DNS-lookup:	0.0002 secs, 0.0000 secs, 0.0016 secs
  req write:	0.0001 secs, 0.0000 secs, 0.0010 secs
  resp wait:	1.1577 secs, 0.9783 secs, 1.8786 secs
  resp read:	0.0003 secs, 0.0002 secs, 0.0009 secs

Status code distribution:
  [200]	10 responses
```

# No preloading

```
Summary:
  Total:	14.9071 secs
  Slowest:	2.1123 secs
  Fastest:	1.0840 secs
  Average:	1.4907 secs
  Requests/sec:	0.6708


Response time histogram:
  1.084 [1]	|■■■■■■■■■■■■■■■■■■■■
  1.187 [1]	|■■■■■■■■■■■■■■■■■■■■
  1.290 [1]	|■■■■■■■■■■■■■■■■■■■■
  1.392 [2]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  1.495 [0]	|
  1.598 [2]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  1.701 [0]	|
  1.804 [1]	|■■■■■■■■■■■■■■■■■■■■
  1.907 [1]	|■■■■■■■■■■■■■■■■■■■■
  2.009 [0]	|
  2.112 [1]	|■■■■■■■■■■■■■■■■■■■■


Latency distribution:
  10% in 1.1699 secs
  25% in 1.3129 secs
  50% in 1.5033 secs
  75% in 1.8290 secs
  90% in 2.1123 secs
  0% in 0.0000 secs
  0% in 0.0000 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0002 secs, 1.0840 secs, 2.1123 secs
  DNS-lookup:	0.0001 secs, 0.0000 secs, 0.0009 secs
  req write:	0.0001 secs, 0.0000 secs, 0.0002 secs
  resp wait:	1.4901 secs, 1.0838 secs, 2.1112 secs
  resp read:	0.0003 secs, 0.0002 secs, 0.0010 secs

Status code distribution:
  [200]	10 responses
```

# Speedup

So far two queries have been ported and the speedup is around 1.5x. Unfortunately, I tested locally with only our own data as I'm having issues with resources for restoring the production db, I'll try it again in the next days.It's likely that the speedup for bigger accounts is already much higher than 1.5x considering that when PG plans get mad the performance can be really bad. In any case, testing with bigger accounts should answer this.

![Screenshot 2021-05-06 at 19 12 03](https://user-images.githubusercontent.com/5599208/117339322-e6ca9000-ae9f-11eb-85cb-b0be94db24b1.png)

As can be seen from the image, the `ReleaseLoader._fetch_precomputed_releases` got a speedup of ~16x, and `PullRequestMiner._fetch_prs_by_filters` got a speedup of ~3x. To be noted that these values are just from a single observation that is the image above, and not coming from a distribution as done for the endpoint wall time. But it's useful to have a rough idea as well of the low-level gain.

# Memory usage for preloading

```
# DB: mdb                                          | [total: 25.66 MiB]

## DataFrame: prs                                  | [total: 25.66 MiB]

# DB: pdb                                          | [total: 904.98 KiB]

## DataFrame: releases                             | [total: 904.98 KiB]
```

