### PR TITLE
Preload on feature flag only

### DIFF
--- a/server/athenian/api/preloading/cache.py
+++ b/server/athenian/api/preloading/cache.py
@@ -279,6 +279,7 @@ def get_memory_cache_options() -> Dict[str, Dict]:
     return {
         "mdb": {
             "prs": {
+                "account_col": PullRequest.acc_id,
                 "cols": [
                     PullRequest.acc_id,
                     PullRequest.node_id,


### PR DESCRIPTION
Closes [DEV-2301](https://athenianco.atlassian.net/browse/DEV-2301).

Locally I tested this PR + these two, https://github.com/athenianco/athenian-api/pull/1400, https://github.com/athenianco/athenian-api/pull/1404, to assess the state of preloading.

# Memory usage

Of course, memory usage benefit a lot from this change:
```
# DB: mdb                                          | [total: 3.43 MiB]

## DataFrame: prs                                  | [total: 3.33 MiB]

## DataFrame: jira_mapping                         | [total: 99.96 KiB]

# DB: pdb                                          | [total: 1.28 MiB]

## DataFrame: releases                             | [total: 1.28 MiB]
```

# Performance Analysis

Analysis on 6 months of data for Faire, with all repos and contribs, running 30 requests with a parallelism of 3 requests.

## With preloading

```
Summary:
  Total:	124.3350 secs
  Slowest:	17.1006 secs
  Fastest:	8.1739 secs
  Average:	12.2867 secs
  Requests/sec:	0.2413

Response time histogram:
  8.174 [1]	|■■■■
  9.067 [2]	|■■■■■■■■
  9.959 [0]	|
  10.852 [7]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  11.745 [0]	|
  12.637 [10]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  13.530 [2]	|■■■■■■■■
  14.423 [2]	|■■■■■■■■
  15.315 [3]	|■■■■■■■■■■■■
  16.208 [0]	|
  17.101 [3]	|■■■■■■■■■■■■


Latency distribution:
  10% in 10.1540 secs
  25% in 10.4313 secs
  50% in 12.3169 secs
  75% in 14.4038 secs
  90% in 16.3760 secs
  95% in 17.1006 secs
  0% in 0.0000 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0003 secs, 8.1739 secs, 17.1006 secs
  DNS-lookup:	0.0002 secs, 0.0000 secs, 0.0022 secs
  req write:	0.0001 secs, 0.0000 secs, 0.0003 secs
  resp wait:	12.2852 secs, 8.1727 secs, 17.0994 secs
  resp read:	0.0011 secs, 0.0008 secs, 0.0015 secs

Status code distribution:
  [200]	30 responses
```

## No Preloading

```
Summary:
  Total:	164.9192 secs
  Slowest:	22.1307 secs
  Fastest:	11.5472 secs
  Average:	16.3540 secs
  Requests/sec:	0.1819


Response time histogram:
  11.547 [1]	|■■■■■■■
  12.606 [0]	|
  13.664 [4]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■
  14.722 [5]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  15.781 [2]	|■■■■■■■■■■■■■
  16.839 [6]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  17.897 [4]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■
  18.956 [3]	|■■■■■■■■■■■■■■■■■■■■
  20.014 [1]	|■■■■■■■
  21.072 [2]	|■■■■■■■■■■■■■
  22.131 [2]	|■■■■■■■■■■■■■


Latency distribution:
  10% in 12.9780 secs
  25% in 14.4884 secs
  50% in 16.2673 secs
  75% in 18.1024 secs
  90% in 20.5193 secs
  95% in 22.1307 secs
  0% in 0.0000 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0004 secs, 11.5472 secs, 22.1307 secs
  DNS-lookup:	0.0003 secs, 0.0000 secs, 0.0040 secs
  req write:	0.0001 secs, 0.0000 secs, 0.0004 secs
  resp wait:	16.3523 secs, 11.5461 secs, 22.1295 secs
  resp read:	0.0012 secs, 0.0007 secs, 0.0015 secs

Status code distribution:
  [200]	30 responses
```

## Thoughts

As described [here](https://github.com/athenianco/athenian-api/pull/1404#issue-633031853), counter-intuitively (at least for me) having a smaller working dataframe didn't help much in reducing the wall time, indeed even in this case the whole endpoint speed up is ~1.3x.

But the preloaded version of the functions in some cases destroyed the non-preloaded version.

![Screenshot 2021-05-10 at 12 13 29](https://user-images.githubusercontent.com/5599208/117650963-a4e86500-b191-11eb-915f-c882a3bf0dd8.png)

As can be seen from the image, we have:
- `ReleaseLoader._fetch_precomputed_releases`: 1058ms -> 275ms (**4x**)
- `PullRequestMiner.fetch_prs`: 1565ms -> 19ms (**82x**)
- `PullRequestJiraMapper.load_pr_jira_mapping`: 1571ms -> 12ms (**130x**)

One thing to consider is the following: the bigger the interval, the more PRs are retrieved, the more with preloading the wall time will be dominated by the metrics calculation.

![Screenshot 2021-05-10 at 13 24 35](https://user-images.githubusercontent.com/5599208/117652129-1543b600-b193-11eb-9ccb-13a652ac85e5.png)

As can be seen from the image, the `BinnedEnsemblesCalculator` contributes differently depending on whether preloading is enabled:
- with preloading (on the left): ~30% (2048ms / 6847ms),
- without preloading (on the right): ~41% (1844ms / 4467ms).

Taking into account that the final goal is not the wall time of the endpoint itself, but the wall time of the endpoint when called in the context of the webapp, I traced also the timings of the endpoint, but when is called during a refresh of the webapp. The results are really interesting. This is the trace with preloading on the default 2 weeks interval:

![Screenshot 2021-05-10 at 12 43 20](https://user-images.githubusercontent.com/5599208/117652569-a1ee7400-b193-11eb-95ad-7953c74c26f7.png)

Let's compare it with the traces with preloading on the 6 months interval that I always use for benchmarking:

![Screenshot 2021-05-10 at 12 44 54](https://user-images.githubusercontent.com/5599208/117652671-baf72500-b193-11eb-894c-e96fa91c64c5.png)

First of all, the contribution of `BinnedEnsemblesCalculator` is much lower as we expected since there are fewer PRs in a smaller interval.

What is very interesting is how some specific SQL queries (see `extract_branches` for example) explode and take much longer on a 2 weeks interval when running as part of the webapp, compared to on a 6 months interval when running "alone". I think this is the effect of what I mentioned being caused by PG being warmed up when hammering always the same endpoint compared to answering to all the requests for a full webapp render. This is also another point in favor of preloading since we can see how the preloaded versions are "stable" independently from the time range (to be more precise rather than "stable" they scale seemingly linearly and without surprises).

From the traces it's clear what will be the next candidates for being preloaded:

![Scratch-184](https://user-images.githubusercontent.com/5599208/117653138-57212c00-b194-11eb-8f03-65c2502b4429.jpg)

Red first, then orange, then yellow. The green ones are queries that are totally fine.

# Conclusion

Once we'll have those functions preloaded as well, we'll be able to assess what's the final gain and where are the new bottlenecks.
