### PR TITLE
Preload on feature flag only

### DIFF
--- a/server/athenian/api/preloading/cache.py
+++ b/server/athenian/api/preloading/cache.py
@@ -287,6 +287,10 @@ def get_memory_cache_options() -> Dict[str, Dict[str, Dict[str, List[Instrumente
     return {
         "mdb": {
             MCID.prs.value: {
+                "sharding": {
+                    "column": PullRequest.acc_id,
+                    "key": "meta_id",
+                },
                 "cols": [
                     PullRequest.acc_id,
                     PullRequest.node_id,
@@ -318,6 +322,10 @@ def get_memory_cache_options() -> Dict[str, Dict[str, Dict[str, List[Instrumente
                 ],
             },
             MCID.jira_mapping.value: {
+                "sharding": {
+                    "column": NodePullRequestJiraIssues.node_acc,
+                    "key": "meta_id",
+                },
                 "cols": [
                     NodePullRequestJiraIssues.node_id,
                     NodePullRequestJiraIssues.node_acc,
@@ -332,6 +340,10 @@ def get_memory_cache_options() -> Dict[str, Dict[str, Dict[str, List[Instrumente
         },
         "pdb": {
             PCID.releases.value: {
+                "sharding": {
+                    "column": PrecomputedRelease.acc_id,
+                    "key": "acc_id",
+                },
                 "cols": [
                     PrecomputedRelease.release_match,
                     PrecomputedRelease.repository_full_name,

--- a/server/athenian/api/preloading/cache.py
+++ b/server/athenian/api/preloading/cache.py
@@ -13,7 +13,11 @@ from athenian.api import metadata
 from athenian.api.async_utils import gather, read_sql_query
 from athenian.api.models.metadata.github import NodePullRequestJiraIssues, PullRequest
 from athenian.api.models.precomputed.models import GitHubRelease as PrecomputedRelease
+from athenian.api.models.state.models import AccountFeature, AccountGitHubAccount, Feature
 from athenian.api.typing_utils import DatabaseLike
+
+
+PRELOADING_FEATURE_FLAG_NAME = "github_features_entries_preloading"
 
 
 def _humanize_size(v):
@@ -41,6 +45,7 @@ class CachedDataFrame:
         categorical_cols: Optional[List[sa.Column]] = None,
         identifier_cols: Optional[List[sa.Column]] = None,
         filtering_clause: Optional[sa.sql.ClauseElement] = None,
+        sharding: Optional[Dict] = None,
         debug_memory: Optional[bool] = False,
     ):
         """Initialize a `CachedDataFrame`.
@@ -57,6 +62,7 @@ class CachedDataFrame:
         self._categorical_cols = categorical_cols or []
         self._identifier_cols = identifier_cols or []
         self._filtering_clause = filtering_clause
+        self._sharding = sharding
         self._db = db
         self._debug_memory = debug_memory
         self._mem = {}
@@ -73,10 +79,19 @@ class CachedDataFrame:
         assert self._df is not None, "Need to await refresh() at least once."
         return self._df
 
+    @property
+    def filtering_clause(self) -> sa.sql.ClauseElement:
+        """Return the filtering clause used for refreshing the data."""
+        return self._filtering_clause
+
+    @filtering_clause.setter
+    def filtering_clause(self, fc: sa.sql.ClauseElement):
+        self._filtering_clause = fc
+
     async def refresh(self) -> "CachedDataFrame":
         """Refresh the DataFrame from the database."""
         query = select(self._cols)
-        if self._filtering_clause:
+        if self._filtering_clause is not None:
             query = query.where(self._filtering_clause)
 
         df = await read_sql_query(query, self._db, self._cols)
@@ -182,11 +197,13 @@ class MemoryCache:
 
     def __init__(
         self,
+        sdb: DatabaseLike,
         db: DatabaseLike,
         options: Dict[str, Dict],
         debug_memory: Optional[bool] = False,
     ):
         """Initialize a `MemoryCache`."""
+        self._sdb = sdb
         self._db = db
         self._options = options
         self._debug_memory = debug_memory
@@ -215,12 +232,44 @@ class MemoryCache:
         else:
             return size_by_df
 
-    async def refresh(self, id_: Optional[str] = None):
+    async def refresh(self, id_: Optional[str] = None) -> None:
         """Refresh the DataFrames from the database."""
         if id_:
-            await self._dfs[id_].refresh()
+            df = self._dfs[id_]
+            df.filtering_clause = await self._build_filtering_clause(id_)
+            await df.refresh()
         else:
-            await gather(*[df.refresh() for df in self._dfs.values()])
+            tasks = []
+            accounts = await self._get_enabled_accounts()
+            for id_, df in self._dfs.items():
+                df.filtering_clause = await self._build_filtering_clause(id_, accounts=accounts)
+                tasks.append(df.refresh())
+
+            await gather(*tasks)
+
+    async def _build_filtering_clause(
+            self, id_: str, accounts: Optional[Dict[str, Collection[int]]] = None,
+    ) -> sa.sql.ClauseElement:
+        if not accounts:
+            accounts = await self._get_enabled_accounts()
+
+        sharding_opts = self._options[id_]["sharding"]
+        return sharding_opts["column"].in_(accounts[sharding_opts["key"]])
+
+    async def _get_enabled_accounts(self) -> Dict[str, List[int]]:
+        query = (
+            sa.select([AccountFeature.account_id])
+            .select_from(sa.join(Feature, AccountFeature,
+                                 Feature.id == AccountFeature.feature_id))
+            .where(sa.and_(AccountFeature.enabled,
+                           Feature.name == PRELOADING_FEATURE_FLAG_NAME))
+        )
+        acc_ids = [r[0] for r in await self._sdb.fetch_all(query)]
+        query = sa.select([AccountGitHubAccount.id]).where(
+            AccountGitHubAccount.account_id.in_(acc_ids))
+        meta_ids = [r[0] for r in await self._sdb.fetch_all(query)]
+
+        return {"acc_id": acc_ids, "meta_id": meta_ids}
 
 
 class MemoryCachePreloader:
@@ -255,7 +304,7 @@ class MemoryCachePreloader:
         tasks = []
         for db_name, opts in get_memory_cache_options().items():
             db = dbs[db_name]
-            db.cache = mc = MemoryCache(db, opts, debug_memory=debug_mode)
+            db.cache = mc = MemoryCache(dbs["sdb"], db, opts, debug_memory=debug_mode)
             tasks.append(mc.refresh())
 
         await gather(*tasks)


### PR DESCRIPTION
Closes [DEV-2301](https://athenianco.atlassian.net/browse/DEV-2301).

Locally I tested this PR + these two, https://github.com/athenianco/athenian-api/pull/1400, https://github.com/athenianco/athenian-api/pull/1404, to assess the state of preloading.

# Memory usage

Of course, memory usage benefits a lot from this change compared to [here](https://github.com/athenianco/athenian-api/pull/1404#issue-633031853) since only Faire is being pre-loaded:
```
# DB: mdb                                          | [total: 18.15 MiB]

## DataFrame: prs                                  | [total: 15.68 MiB]

## DataFrame: jira_mapping                         | [total: 2.47 MiB]

# DB: pdb                                          | [total: 1.29 MiB]

## DataFrame: releases                             | [total: 1.29 MiB]
```

# Performance Analysis

Analysis on 6 months of data for Faire, with all repos and contribs, running 30 requests with a parallelism of 3 requests.

## With preloading

```
Summary:
  Total:	156.0242 secs
  Slowest:	21.1123 secs
  Fastest:	9.9842 secs
  Average:	15.4472 secs
  Requests/sec:	0.1923


Response time histogram:
  9.984 [1]	|■■■■
  11.097 [2]	|■■■■■■■■■
  12.210 [0]	|
  13.323 [5]	|■■■■■■■■■■■■■■■■■■■■■■
  14.435 [0]	|
  15.548 [9]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  16.661 [6]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■
  17.774 [2]	|■■■■■■■■■
  18.887 [0]	|
  20.000 [0]	|
  21.112 [5]	|■■■■■■■■■■■■■■■■■■■■■■


Latency distribution:
  10% in 12.5475 secs
  25% in 14.8206 secs
  50% in 15.3984 secs
  75% in 17.5669 secs
  90% in 20.3324 secs
  95% in 21.1123 secs
  0% in 0.0000 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0005 secs, 9.9842 secs, 21.1123 secs
  DNS-lookup:	0.0003 secs, 0.0000 secs, 0.0028 secs
  req write:	0.0001 secs, 0.0000 secs, 0.0005 secs
  resp wait:	15.4448 secs, 9.9819 secs, 21.1114 secs
  resp read:	0.0017 secs, 0.0008 secs, 0.0147 secs

Status code distribution:
  [200]	30 responses
```

## No Preloading

```
Summary:
  Total:	240.6772 secs
  Slowest:	38.6044 secs
  Fastest:	16.1203 secs
  Average:	23.8168 secs
  Requests/sec:	0.1246


Response time histogram:
  16.120 [1]	|■■■■
  18.369 [3]	|■■■■■■■■■■■■■
  20.617 [4]	|■■■■■■■■■■■■■■■■■■
  22.866 [9]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  25.114 [4]	|■■■■■■■■■■■■■■■■■■
  27.362 [2]	|■■■■■■■■■
  29.611 [3]	|■■■■■■■■■■■■■
  31.859 [1]	|■■■■
  34.108 [1]	|■■■■
  36.356 [1]	|■■■■
  38.604 [1]	|■■■■


Latency distribution:
  10% in 17.9320 secs
  25% in 20.7097 secs
  50% in 22.7777 secs
  75% in 27.9529 secs
  90% in 33.3619 secs
  95% in 38.6044 secs
  0% in 0.0000 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0003 secs, 16.1203 secs, 38.6044 secs
  DNS-lookup:	0.0002 secs, 0.0000 secs, 0.0021 secs
  req write:	0.0001 secs, 0.0000 secs, 0.0005 secs
  resp wait:	23.8145 secs, 16.1001 secs, 38.6033 secs
  resp read:	0.0019 secs, 0.0008 secs, 0.0172 secs

Status code distribution:
  [200]	30 responses
```

## Thoughts

As described [here](https://github.com/athenianco/athenian-api/pull/1404#issue-633031853), having a smaller working dataframe helped to reduce the wall time, indeed in this case the whole endpoint speed up is **~1.5x** (by comparing the medians: ~15.40s vs ~22.78s).

The [preloaded version](https://sentry.io/organizations/athenianco/performance/api:b31f6fed2c53499bae4bcd0a6831566a/?environment=development-experiment&project=1867351&query=transaction.duration%3A%3C15m+event.type%3Atransaction&showTransactions=recent&statsPeriod=1h&transaction=POST+%2Fv1%2Fmetrics%2Fprs&unselectedSeries=p100%28%29) of the functions in some cases destroyed the [non-preloaded version](https://sentry.io/organizations/athenianco/performance/api:9b8f38308b5643b7bcf54ae973c8bd9f/?environment=development-baseline&project=1867351&query=transaction.duration%3A%3C15m+event.type%3Atransaction&showTransactions=recent&statsPeriod=1h&transaction=POST+%2Fv1%2Fmetrics%2Fprs&unselectedSeries=p100%28%29).

![Screenshot 2021-05-10 at 17 03 41](https://user-images.githubusercontent.com/5599208/117680746-bd687780-b1b1-11eb-9702-8c786a722187.png)

As can be seen from the image, we have:
- `ReleaseLoader._fetch_precomputed_releases`: 1527ms -> 336ms (**4.5x**)
- `PullRequestMiner.fetch_prs`: 2194ms -> 31ms (**70x**)
- `PullRequestJiraMapper.load_pr_jira_mapping`: 2096ms -> 31ms (**68x**)

One thing to consider is the following: the bigger the interval, the more PRs are retrieved, the more with preloading the wall time will be dominated by the metrics calculation.

![Screenshot 2021-05-10 at 17 06 48](https://user-images.githubusercontent.com/5599208/117681215-2819b300-b1b2-11eb-9aeb-c79a3e8070f9.png)

As can be seen from the image, the `BinnedEnsemblesCalculator` contributes differently depending on whether preloading is enabled:
- with preloading (on the left): ~27% (2091ms / 7880ms),
- without preloading (on the right): ~40% (2056ms / 5150ms).

Taking into account that the final goal is not the wall time of the endpoint itself, but the wall time of the endpoint when called in the context of the webapp, I traced also the timings of the endpoint, but when is called during a refresh of the webapp. The results are really interesting. This is the [trace with preloading on the default 2 weeks interval](https://sentry.io/organizations/athenianco/performance/api:adcf839823f34da895048e7b119e507e/?environment=development-experiment&project=1867351&query=transaction.duration%3A%3C15m+event.type%3Atransaction&showTransactions=recent&statsPeriod=1h&transaction=POST+%2Fv1%2Fmetrics%2Fprs&unselectedSeries=p100%28%29):

![Screenshot 2021-05-10 at 17 14 49](https://user-images.githubusercontent.com/5599208/117682403-4d5af100-b1b3-11eb-95b0-8de07c4f3614.png)

Let's compare it with the [traces with preloading on the 6 months interval](https://sentry.io/organizations/athenianco/performance/api:b31f6fed2c53499bae4bcd0a6831566a/?environment=development-experiment&project=1867351&query=transaction.duration%3A%3C15m+event.type%3Atransaction&showTransactions=recent&statsPeriod=1h&transaction=POST+%2Fv1%2Fmetrics%2Fprs&unselectedSeries=p100%28%29) that I always use for benchmarking:

![Screenshot 2021-05-10 at 17 15 02](https://user-images.githubusercontent.com/5599208/117682423-5350d200-b1b3-11eb-9347-bb1e36213c9e.png)

First of all, the contribution of `BinnedEnsemblesCalculator` is much lower as we expected since there are fewer PRs in a smaller interval.

What is very interesting, is how some specific SQL queries (see `extract_branches` for example) explode and take much longer on a 2 weeks interval when running as part of the webapp, compared to ths 6 months interval when running "alone". I think this is the effect of what I mentioned being caused by PG being warmed up when hammering always the same endpoint compared to answering all the requests for a full webapp render (and also more concurrent queries to the database). This is also another point in favor of preloading since we can see how the preloaded versions are "stable" independently from the time range (to be more precise rather than "stable" they scale seemingly linearly and without surprises).

From the traces it's clear what will be the next candidates for being preloaded:

![Scratch-188](https://user-images.githubusercontent.com/5599208/117684122-fbb36600-b1b4-11eb-9b55-12ba84e579ce.jpg)

Red first, then orange, then yellow. The green ones are queries that are totally fine.

# Conclusion

Once we'll have those functions preloaded as well, we'll be able to assess what's the final gain and where are the new bottlenecks. In particular, as can be seen from the traces, there are some functions that take much time before running the SQL query itself. Maybe there's something that can be improved there as well, or maybe it's the time required for "building" the SQLA query that is going to be removed by preloading.

Moreover, so far all the analyses have been done locally which is not accurate compared to doing it in production.
