### PR TITLE
Preloading fix tests

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -200,7 +200,7 @@ jobs:
         set -x
         export WITH_PRELOADING=1
         export SLACK_API_TOKEN=
-        godotenv -s pytest -n 4 $LIMIT --log-level=info --cov-report=xml --cov=athenian.api tests/controllers/test_metrics_controller.py tests/controllers/test_histograms_controller.py
+        godotenv -s pytest -n 4 $LIMIT --log-level=info --benchmark-skip --cov-report=xml --cov=athenian.api tests/controllers/test_metrics_controller.py tests/controllers/test_histograms_controller.py tests/controllers/miners
     - name: test heater
       if: matrix.type == 'heater'
       working-directory: server

--- a/server/athenian/api/controllers/events_controller.py
+++ b/server/athenian/api/controllers/events_controller.py
@@ -13,7 +13,7 @@ from athenian.api.controllers.account import get_metadata_account_ids
 from athenian.api.controllers.features.entries import MetricEntriesCalculator
 from athenian.api.controllers.miners.access_classes import access_classes
 from athenian.api.controllers.miners.filters import JIRAFilter, LabelFilter
-from athenian.api.controllers.miners.github.branches import extract_branches
+from athenian.api.controllers.miners.github.branches import BranchMiner
 from athenian.api.controllers.miners.github.release_mine import mine_releases
 from athenian.api.controllers.prefixer import Prefixer
 from athenian.api.controllers.reposet import resolve_repos
@@ -203,7 +203,7 @@ async def clear_precomputed_events(request: AthenianWebRequest, body: dict) -> w
         no_time_from = datetime(1970, 1, 1, tzinfo=timezone.utc)
         time_from = time_to - timedelta(days=365 * 2)
         (branches, default_branches), settings = await gather(
-            extract_branches(repos, meta_ids, mdb, cache),
+            BranchMiner.extract_branches(repos, meta_ids, mdb, cache),
             Settings.from_account(model.account, sdb, mdb, cache, None)
             .list_release_matches(prefixed_repos))
         await mine_releases(

--- a/server/athenian/api/controllers/features/everything.py
+++ b/server/athenian/api/controllers/features/everything.py
@@ -20,8 +20,7 @@ from athenian.api.controllers.miners.github.contributors import mine_contributor
 from athenian.api.controllers.miners.github.developer import DeveloperTopic, \
     mine_developer_activities
 from athenian.api.controllers.miners.github.precomputed_prs import \
-    load_merged_pull_request_facts_all, load_open_pull_request_facts_all, \
-    load_precomputed_done_facts_all
+    load_merged_pull_request_facts_all, load_precomputed_done_facts_all, OpenPRFactsLoader
 from athenian.api.controllers.miners.github.release_mine import mine_releases
 from athenian.api.controllers.miners.jira.issue import fetch_jira_issues, PullRequestJiraMapper
 from athenian.api.controllers.prefixer import Prefixer, PrefixerPromise
@@ -60,7 +59,8 @@ async def mine_all_prs(repos: Collection[str],
         extra=[ghdprf.release_url, ghdprf.release_node_id])
     merged_facts = await load_merged_pull_request_facts_all(repos, done_facts, account, pdb)
     merged_node_ids = list(chain(done_facts.keys(), merged_facts.keys()))
-    open_facts = await load_open_pull_request_facts_all(repos, merged_node_ids, account, pdb)
+    open_facts = await OpenPRFactsLoader.load_open_pull_request_facts_all(
+        repos, merged_node_ids, account, pdb)
     del merged_node_ids
     facts = {**open_facts, **merged_facts, **done_facts}
     del open_facts

--- a/server/athenian/api/controllers/features/everything.py
+++ b/server/athenian/api/controllers/features/everything.py
@@ -23,7 +23,7 @@ from athenian.api.controllers.miners.github.precomputed_prs import \
     load_merged_pull_request_facts_all, load_open_pull_request_facts_all, \
     load_precomputed_done_facts_all
 from athenian.api.controllers.miners.github.release_mine import mine_releases
-from athenian.api.controllers.miners.jira.issue import append_pr_jira_mapping, fetch_jira_issues
+from athenian.api.controllers.miners.jira.issue import fetch_jira_issues, PullRequestJiraMapper
 from athenian.api.controllers.prefixer import Prefixer, PrefixerPromise
 from athenian.api.controllers.settings import ReleaseSettings
 from athenian.api.models.metadata.github import PullRequest, Release, User
@@ -71,7 +71,7 @@ async def mine_all_prs(repos: Collection[str],
             PullRequest.acc_id.in_(meta_ids),
             PullRequest.node_id.in_(facts),
         )), mdb, PullRequest, index=PullRequest.node_id.key),
-        append_pr_jira_mapping(facts, meta_ids, mdb),
+        PullRequestJiraMapper.append_pr_jira_mapping(facts, meta_ids, mdb),
     ]
     df_prs, _ = await gather(*tasks, op="fetch raw data")
     df_facts = df_from_structs(facts.values())

--- a/server/athenian/api/controllers/features/everything.py
+++ b/server/athenian/api/controllers/features/everything.py
@@ -14,7 +14,7 @@ from athenian.api.controllers.features.metric_calculator import df_from_structs
 from athenian.api.controllers.jira import get_jira_installation, load_mapped_jira_users
 from athenian.api.controllers.jira_controller import participant_columns
 from athenian.api.controllers.miners.filters import JIRAFilter, LabelFilter
-from athenian.api.controllers.miners.github.branches import extract_branches
+from athenian.api.controllers.miners.github.branches import BranchMiner
 from athenian.api.controllers.miners.github.check_run import mine_check_runs
 from athenian.api.controllers.miners.github.contributors import mine_contributors
 from athenian.api.controllers.miners.github.developer import DeveloperTopic, \
@@ -223,7 +223,7 @@ async def mine_everything(topics: Set[MineTopic],
     """Mine all the specified data topics."""
     repos = settings.native.keys()
     prefixer = Prefixer.schedule_load(meta_ids, mdb)
-    branches, default_branches = await extract_branches(repos, meta_ids, mdb, cache)
+    branches, default_branches = await BranchMiner.extract_branches(repos, meta_ids, mdb, cache)
     tasks = [miners[t](repos, branches, default_branches, settings, prefixer,
                        account, meta_ids, sdb, mdb, pdb, rdb, cache)
              for t in topics]

--- a/server/athenian/api/controllers/features/github/pull_request_filter.py
+++ b/server/athenian/api/controllers/features/github/pull_request_filter.py
@@ -23,7 +23,7 @@ from athenian.api.controllers.features.metric import Metric
 from athenian.api.controllers.features.metric_calculator import df_from_structs, MetricCalculator
 from athenian.api.controllers.miners.filters import JIRAFilter, LabelFilter
 from athenian.api.controllers.miners.github.bots import bots
-from athenian.api.controllers.miners.github.branches import extract_branches
+from athenian.api.controllers.miners.github.branches import BranchMiner
 from athenian.api.controllers.miners.github.commit import BRANCH_FETCH_COMMITS_COLUMNS, \
     fetch_precomputed_commit_history_dags, fetch_repository_commits_no_branch_dates
 from athenian.api.controllers.miners.github.precomputed_prs import \
@@ -557,7 +557,7 @@ async def _filter_pull_requests(events: Set[PullRequestEvent],
     date_from, date_to = coarsen_time_interval(time_from, time_to)
     if updated_min is not None:
         coarsen_time_interval(updated_min, updated_max)
-    branches, default_branches = await extract_branches(repos, meta_ids, mdb, cache)
+    branches, default_branches = await BranchMiner.extract_branches(repos, meta_ids, mdb, cache)
     tasks = (
         PullRequestMiner.mine(
             date_from, date_to, time_from, time_to, repos, participants,
@@ -713,7 +713,7 @@ async def _fetch_pull_requests(prs: Dict[str, Set[int]],
                                           PRDataFrames,
                                           Dict[str, PullRequestFacts],
                                           Dict[str, ReleaseMatch]]:
-    branches, default_branches = await extract_branches(prs, meta_ids, mdb, cache)
+    branches, default_branches = await BranchMiner.extract_branches(prs, meta_ids, mdb, cache)
     filters = [and_(PullRequest.repository_full_name == repo,
                     PullRequest.number.in_(numbers),
                     PullRequest.acc_id.in_(meta_ids))

--- a/server/athenian/api/controllers/features/github/pull_request_filter.py
+++ b/server/athenian/api/controllers/features/github/pull_request_filter.py
@@ -33,7 +33,7 @@ from athenian.api.controllers.miners.github.precomputed_prs import \
     store_precomputed_done_facts
 from athenian.api.controllers.miners.github.pull_request import ImpossiblePullRequest, \
     PRDataFrames, PullRequestFactsMiner, PullRequestMiner, ReviewResolution
-from athenian.api.controllers.miners.github.release_load import dummy_releases_df, load_releases
+from athenian.api.controllers.miners.github.release_load import dummy_releases_df, ReleaseLoader
 from athenian.api.controllers.miners.github.release_match import load_commit_dags
 from athenian.api.controllers.miners.types import Label, MinedPullRequest, PRParticipants, \
     PullRequestEvent, PullRequestFacts, PullRequestJIRAIssueItem, PullRequestListItem, \
@@ -790,7 +790,7 @@ async def unwrap_pull_requests(prs_df: pd.DataFrame,
         milestone_releases = dummy_releases_df().append(milestone_prs.reset_index(drop=True))
         milestone_releases = milestone_releases.take(np.where(
             milestone_releases[Release.sha.key].notnull())[0])
-        releases, matched_bys = await load_releases(
+        releases, matched_bys = await ReleaseLoader.load_releases(
             prs_df[PullRequest.repository_full_name.key].unique(), branches, default_branches,
             rel_time_from, now, release_settings, account, meta_ids, mdb, pdb, rdb, cache)
         add_pdb_misses(pdb, "load_precomputed_done_facts_reponums/ambiguous",

--- a/server/athenian/api/controllers/features/github/unfresh_pull_request_metrics.py
+++ b/server/athenian/api/controllers/features/github/unfresh_pull_request_metrics.py
@@ -163,9 +163,3 @@ class UnfreshPullRequestFactsFetcher:
             [PullRequest.node_id.in_(node_ids), PullRequest.acc_id.in_(meta_ids)],
             jira, mdb, cache, columns=columns)
         return await read_sql_query(query, mdb, columns, index=PullRequest.node_id.key)
-
-
-# TODO: these have to be removed, these are here just for keeping backward-compatibility
-# without the need to re-write already all the places these functions are called
-fetch_pull_request_facts_unfresh = \
-    UnfreshPullRequestFactsFetcher.fetch_pull_request_facts_unfresh

--- a/server/athenian/api/controllers/filter_controller.py
+++ b/server/athenian/api/controllers/filter_controller.py
@@ -23,7 +23,7 @@ from athenian.api.controllers.jira import get_jira_installation, get_jira_instal
     load_mapped_jira_users
 from athenian.api.controllers.miners.access_classes import access_classes
 from athenian.api.controllers.miners.filters import JIRAFilter, LabelFilter
-from athenian.api.controllers.miners.github.branches import extract_branches
+from athenian.api.controllers.miners.github.branches import BranchMiner
 from athenian.api.controllers.miners.github.commit import extract_commits, FilterCommitsProperty
 from athenian.api.controllers.miners.github.contributors import mine_contributors
 from athenian.api.controllers.miners.github.label import mine_labels
@@ -345,7 +345,7 @@ async def filter_releases(request: AthenianWebRequest, body: dict) -> web.Respon
     ]
     settings, jira_ids = await gather(*tasks)
     repos = [r.split("/", 1)[1] for r in repos]
-    branches, default_branches = await extract_branches(
+    branches, default_branches = await BranchMiner.extract_branches(
         repos, meta_ids, request.mdb, request.cache)
     releases, avatars, _ = await mine_releases(
         repos, participants, branches, default_branches, filt.date_from, filt.date_to,

--- a/server/athenian/api/controllers/jira_controller.py
+++ b/server/athenian/api/controllers/jira_controller.py
@@ -31,7 +31,7 @@ from athenian.api.controllers.filter_controller import web_pr_from_struct
 from athenian.api.controllers.jira import get_jira_installation, normalize_issue_type, \
     normalize_user_type
 from athenian.api.controllers.miners.filters import LabelFilter
-from athenian.api.controllers.miners.github.branches import extract_branches
+from athenian.api.controllers.miners.github.branches import BranchMiner
 from athenian.api.controllers.miners.github.precomputed_prs import load_precomputed_done_facts_ids
 from athenian.api.controllers.miners.jira.epic import filter_epics
 from athenian.api.controllers.miners.jira.issue import fetch_jira_issues, ISSUE_PR_IDS, \
@@ -798,7 +798,7 @@ async def _collect_ids(account: int,
     ]
     repos, jira_ids, meta_ids = await gather(*tasks, op="sdb/ids")
     tasks = [
-        extract_branches(
+        BranchMiner.extract_branches(
             [r.split("/", 1)[1] for r in repos], meta_ids, mdb, cache),
         Settings.from_request(request, account).list_release_matches(repos),
     ]

--- a/server/athenian/api/controllers/miners/github/branches.py
+++ b/server/athenian/api/controllers/miners/github/branches.py
@@ -155,8 +155,3 @@ async def load_branch_commit_dates(branches: pd.DataFrame,
 def dummy_branches_df() -> pd.DataFrame:
     """Create an empty dataframe with Branch columns."""
     return pd.DataFrame(columns=[c.name for c in Branch.__table__.columns])
-
-
-# TODO: these have to be removed, these are here just for keeping backward-compatibility
-# without the need to re-write already all the places these functions are called
-extract_branches = BranchMiner.extract_branches

--- a/server/athenian/api/controllers/miners/github/contributors.py
+++ b/server/athenian/api/controllers/miners/github/contributors.py
@@ -15,7 +15,7 @@ from athenian.api.async_utils import gather
 from athenian.api.cache import cached
 from athenian.api.controllers.miners.github.bots import Bots
 from athenian.api.controllers.miners.github.branches import BranchMiner
-from athenian.api.controllers.miners.github.release_load import load_releases
+from athenian.api.controllers.miners.github.release_load import ReleaseLoader
 from athenian.api.controllers.settings import ReleaseSettings
 from athenian.api.models.metadata.github import NodeCommit, NodeRepository, OrganizationMember, \
     PullRequest, PullRequestComment, PullRequestReview, PushCommit, Release, User
@@ -182,7 +182,7 @@ async def mine_contributors(repos: Collection[str],
             rt_from = datetime(1970, 1, 1, tzinfo=timezone.utc)
             now = datetime.now(timezone.utc) + timedelta(days=1)
             rt_to = datetime(now.year, now.month, now.day, tzinfo=timezone.utc)
-        releases, _ = await load_releases(
+        releases, _ = await ReleaseLoader.load_releases(
             repos, branches, default_branches, rt_from, rt_to,
             release_settings, account, meta_ids, mdb, pdb, rdb, cache,
             force_fresh=force_fresh_releases)

--- a/server/athenian/api/controllers/miners/github/contributors.py
+++ b/server/athenian/api/controllers/miners/github/contributors.py
@@ -14,7 +14,7 @@ from sqlalchemy.sql.functions import coalesce
 from athenian.api.async_utils import gather
 from athenian.api.cache import cached
 from athenian.api.controllers.miners.github.bots import Bots
-from athenian.api.controllers.miners.github.branches import extract_branches
+from athenian.api.controllers.miners.github.branches import BranchMiner
 from athenian.api.controllers.miners.github.release_load import load_releases
 from athenian.api.controllers.settings import ReleaseSettings
 from athenian.api.models.metadata.github import NodeCommit, NodeRepository, OrganizationMember, \
@@ -64,7 +64,7 @@ async def mine_contributors(repos: Collection[str],
         PullRequest.acc_id.in_(meta_ids),
     ]
     tasks = [
-        extract_branches(repos, meta_ids, mdb, cache),
+        BranchMiner.extract_branches(repos, meta_ids, mdb, cache),
         mdb.fetch_all(select([NodeRepository.node_id])
                       .where(and_(NodeRepository.name_with_owner.in_(repos),
                                   NodeRepository.acc_id.in_(meta_ids)))),

--- a/server/athenian/api/controllers/miners/github/developer.py
+++ b/server/athenian/api/controllers/miners/github/developer.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm.attributes import InstrumentedAttribute
 
 from athenian.api.async_utils import gather, read_sql_query
 from athenian.api.controllers.miners.filters import JIRAFilter, LabelFilter
-from athenian.api.controllers.miners.github.branches import extract_branches
+from athenian.api.controllers.miners.github.branches import BranchMiner
 from athenian.api.controllers.miners.github.release_load import load_releases
 from athenian.api.controllers.miners.jira.issue import generate_jira_prs_query
 from athenian.api.controllers.settings import ReleaseSettings
@@ -177,7 +177,8 @@ async def _mine_releases(repo_ids: np.ndarray,
                          rdb: databases.Database,
                          cache: Optional[aiomcache.Client],
                          ) -> pd.DataFrame:
-    branches, default_branches = await extract_branches(repo_names, meta_ids, mdb, cache)
+    branches, default_branches = await BranchMiner.extract_branches(
+        repo_names, meta_ids, mdb, cache)
     releases, _ = await load_releases(
         repo_names, branches, default_branches, time_from, time_to,
         release_settings, account, meta_ids, mdb, pdb, rdb, cache)

--- a/server/athenian/api/controllers/miners/github/developer.py
+++ b/server/athenian/api/controllers/miners/github/developer.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm.attributes import InstrumentedAttribute
 from athenian.api.async_utils import gather, read_sql_query
 from athenian.api.controllers.miners.filters import JIRAFilter, LabelFilter
 from athenian.api.controllers.miners.github.branches import BranchMiner
-from athenian.api.controllers.miners.github.release_load import load_releases
+from athenian.api.controllers.miners.github.release_load import ReleaseLoader
 from athenian.api.controllers.miners.jira.issue import generate_jira_prs_query
 from athenian.api.controllers.settings import ReleaseSettings
 from athenian.api.models.metadata.github import PullRequest, PullRequestComment, \
@@ -179,7 +179,7 @@ async def _mine_releases(repo_ids: np.ndarray,
                          ) -> pd.DataFrame:
     branches, default_branches = await BranchMiner.extract_branches(
         repo_names, meta_ids, mdb, cache)
-    releases, _ = await load_releases(
+    releases, _ = await ReleaseLoader.load_releases(
         repo_names, branches, default_branches, time_from, time_to,
         release_settings, account, meta_ids, mdb, pdb, rdb, cache)
     release_authors = releases[Release.author.key].values.astype("U")

--- a/server/athenian/api/controllers/miners/github/precomputed_prs.py
+++ b/server/athenian/api/controllers/miners/github/precomputed_prs.py
@@ -436,7 +436,7 @@ def _post_process_ambiguous_done_prs(result: Dict[str, Mapping[str, Any]],
     result.update(ambiguous[ReleaseMatch.tag.name])
     repokey = GitHubDonePullRequestFacts.repository_full_name.key
     # We've found PRs released by tag belonging to these repos.
-    # This means that we are going to load tags in load_releases().
+    # This means that we are going to load tags in ReleaseLoader.load_releases().
     confirmed_tag_repos = {obj[repokey] for obj in ambiguous[ReleaseMatch.tag.name].values()}
     ambiguous_prs = defaultdict(list)
     for node_id, obj in ambiguous[ReleaseMatch.branch.name].items():

--- a/server/athenian/api/controllers/miners/github/precomputed_prs.py
+++ b/server/athenian/api/controllers/miners/github/precomputed_prs.py
@@ -21,7 +21,7 @@ from athenian.api import metadata
 from athenian.api.async_utils import gather
 from athenian.api.cache import cached
 from athenian.api.controllers.miners.filters import LabelFilter
-from athenian.api.controllers.miners.github.branches import extract_branches, \
+from athenian.api.controllers.miners.github.branches import BranchMiner, \
     load_branch_commit_dates
 from athenian.api.controllers.miners.github.commit import BRANCH_FETCH_COMMITS_COLUMNS, \
     fetch_precomputed_commit_history_dags, fetch_repository_commits
@@ -1425,7 +1425,7 @@ async def delete_force_push_dropped_prs(repos: Iterable[str],
     """
     @sentry_span
     async def fetch_branches():
-        branches, _ = await extract_branches(repos, meta_ids, mdb, cache)
+        branches, _ = await BranchMiner.extract_branches(repos, meta_ids, mdb, cache)
         await load_branch_commit_dates(branches, meta_ids, mdb)
         return branches
 

--- a/server/athenian/api/controllers/miners/github/precomputed_prs.py
+++ b/server/athenian/api/controllers/miners/github/precomputed_prs.py
@@ -1466,10 +1466,3 @@ async def delete_force_push_dropped_prs(repos: Iterable[str],
             .where(and_(ghdprf.pr_node_id.in_(dead_pr_node_ids),
                         ghdprf.release_match != ReleaseMatch.force_push_drop.name)))
     return dead_pr_node_ids
-
-
-# TODO: these have to be removed, these are here just for keeping backward-compatibility
-# without the need to re-write already all the places these functions are called
-load_open_pull_request_facts = OpenPRFactsLoader.load_open_pull_request_facts
-load_open_pull_request_facts_unfresh = OpenPRFactsLoader.load_open_pull_request_facts_unfresh
-load_open_pull_request_facts_all = OpenPRFactsLoader.load_open_pull_request_facts_all

--- a/server/athenian/api/controllers/miners/github/pull_request.py
+++ b/server/athenian/api/controllers/miners/github/pull_request.py
@@ -28,7 +28,7 @@ from athenian.api.controllers.miners.github.commit import BRANCH_FETCH_COMMITS_C
 from athenian.api.controllers.miners.github.dag_accelerated import searchsorted_inrange
 from athenian.api.controllers.miners.github.precomputed_prs import \
     discover_inactive_merged_unreleased_prs, load_merged_unreleased_pull_request_facts, \
-    load_open_pull_request_facts, update_unreleased_prs
+    OpenPRFactsLoader, update_unreleased_prs
 from athenian.api.controllers.miners.github.release_match import PullRequestToReleaseMapper, \
     ReleaseToPullRequestMapper
 from athenian.api.controllers.miners.github.released_pr import matched_by_column
@@ -283,7 +283,7 @@ class PullRequestMiner:
                 prs, unreleased.index, time_to, releases, matched_bys, branches,
                 default_branches, release_dags, release_settings, account, meta_ids,
                 mdb, pdb, cache, truncate=truncate),
-            load_open_pull_request_facts(prs, account, pdb),
+            OpenPRFactsLoader.load_open_pull_request_facts(prs, account, pdb),
         ]
         (dfs, unreleased_facts, unreleased_prs_event), open_facts = await gather(
             *tasks, op="PullRequestMiner.mine/external_data")

--- a/server/athenian/api/controllers/miners/github/release_load.py
+++ b/server/athenian/api/controllers/miners/github/release_load.py
@@ -901,11 +901,3 @@ class ReleaseMatcher:
                             PushCommit.acc_id.in_(self._meta_ids))) \
                 .order_by(desc(PushCommit.committed_date))
         return await read_sql_query(query, self._mdb, PushCommit)
-
-
-# TODO: these have to be removed, these are here just for keeping backward-compatibility
-# without the need to re-write already all the places these functions are called
-load_releases = ReleaseLoader.load_releases
-fetch_precomputed_release_match_spans = ReleaseLoader.fetch_precomputed_release_match_spans
-_fetch_precomputed_releases = ReleaseLoader._fetch_precomputed_releases
-_store_precomputed_release_match_spans = ReleaseLoader._store_precomputed_release_match_spans

--- a/server/athenian/api/controllers/miners/github/release_match.py
+++ b/server/athenian/api/controllers/miners/github/release_match.py
@@ -217,11 +217,6 @@ class PullRequestToReleaseMapper:
         return labels
 
 
-# TODO: these have to be removed, these are here just for keeping backward-compatibility
-# without the need to re-write already all the places these functions are called
-map_prs_to_releases = PullRequestToReleaseMapper.map_prs_to_releases
-
-
 class ReleaseToPullRequestMapper:
     """Mapper from releases to pull requests."""
 
@@ -617,12 +612,3 @@ class ReleaseToPullRequestMapper:
         deleted_indexes = deleted_indexes[deleted_indexes < len(visited_hashes)]
         released_hashes = np.delete(visited_hashes, deleted_indexes)
         return released_hashes
-
-
-# TODO: these have to be removed, these are here just for keeping backward-compatibility
-# without the need to re-write already all the places these functions are called
-map_releases_to_prs = ReleaseToPullRequestMapper.map_releases_to_prs
-_fetch_repository_first_commit_dates = \
-    ReleaseToPullRequestMapper._fetch_repository_first_commit_dates
-_find_releases_for_matching_prs = ReleaseToPullRequestMapper._find_releases_for_matching_prs
-_find_dead_merged_prs = PullRequestToReleaseMapper._find_dead_merged_prs

--- a/server/athenian/api/controllers/miners/github/release_mine.py
+++ b/server/athenian/api/controllers/miners/github/release_mine.py
@@ -17,7 +17,7 @@ from athenian.api import metadata
 from athenian.api.async_utils import gather, read_sql_query
 from athenian.api.cache import cached, CancelCache
 from athenian.api.controllers.miners.filters import JIRAFilter
-from athenian.api.controllers.miners.github.branches import extract_branches
+from athenian.api.controllers.miners.github.branches import BranchMiner
 from athenian.api.controllers.miners.github.commit import fetch_precomputed_commit_history_dags, \
     fetch_repository_commits, RELEASE_FETCH_COMMITS_COLUMNS
 from athenian.api.controllers.miners.github.dag_accelerated import extract_subdag, \
@@ -614,7 +614,7 @@ async def _load_releases_by_name(names: Dict[str, Set[str]],
                                             Dict[str, str]]:
     names = await _complete_commit_hashes(names, meta_ids, mdb)
     tasks = [
-        extract_branches(names, meta_ids, mdb, cache),
+        BranchMiner.extract_branches(names, meta_ids, mdb, cache),
         fetch_precomputed_releases_by_name(names, account, pdb),
     ]
     (branches, default_branches), releases = await gather(*tasks)

--- a/server/athenian/api/controllers/miners/github/release_mine.py
+++ b/server/athenian/api/controllers/miners/github/release_mine.py
@@ -28,7 +28,7 @@ from athenian.api.controllers.miners.github.precomputed_releases import \
 from athenian.api.controllers.miners.github.release_load import \
     group_repos_by_release_match, ReleaseLoader
 from athenian.api.controllers.miners.github.release_match import \
-    _fetch_repository_first_commit_dates, _find_releases_for_matching_prs, load_commit_dags
+    load_commit_dags, ReleaseToPullRequestMapper
 from athenian.api.controllers.miners.github.released_pr import matched_by_column
 from athenian.api.controllers.miners.github.users import mine_user_avatars
 from athenian.api.controllers.miners.jira.issue import generate_jira_prs_query
@@ -142,13 +142,13 @@ async def mine_releases(repos: Iterable[str],
         releases_in_time_range = releases_in_time_range.take(np.where(
             releases_in_time_range[Release.repository_full_name.key].isin(missing_repos).values,
         )[0])
-        _, releases, _, _ = await _find_releases_for_matching_prs(
+        _, releases, _, _ = await ReleaseToPullRequestMapper._find_releases_for_matching_prs(
             missing_repos, branches, default_branches, time_from, time_to, False,
             settings, account, meta_ids, mdb, pdb, rdb, cache,
             releases_in_time_range=releases_in_time_range)
         tasks = [
             load_commit_dags(releases, account, meta_ids, mdb, pdb, cache),
-            _fetch_repository_first_commit_dates(
+            ReleaseToPullRequestMapper._fetch_repository_first_commit_dates(
                 missing_repos, account, meta_ids, mdb, pdb, cache),
         ]
         dags, first_commit_dates = await gather(*tasks, op="mine_releases/commits")

--- a/server/athenian/api/controllers/miners/github/repositories.py
+++ b/server/athenian/api/controllers/miners/github/repositories.py
@@ -12,7 +12,7 @@ from sqlalchemy.sql.functions import coalesce
 from athenian.api.async_utils import gather
 from athenian.api.cache import cached
 from athenian.api.controllers.miners.filters import LabelFilter
-from athenian.api.controllers.miners.github.branches import extract_branches
+from athenian.api.controllers.miners.github.branches import BranchMiner
 from athenian.api.controllers.miners.github.precomputed_prs import \
     discover_inactive_merged_unreleased_prs
 from athenian.api.controllers.settings import ReleaseMatch, ReleaseSettings
@@ -96,7 +96,7 @@ async def mine_repositories(repos: Collection[str],
 
     @sentry_span
     async def fetch_inactive_merged_prs():
-        _, default_branches = await extract_branches(repos, meta_ids, mdb, cache)
+        _, default_branches = await BranchMiner.extract_branches(repos, meta_ids, mdb, cache)
         _, inactive_repos = await discover_inactive_merged_unreleased_prs(
             time_from, time_to, repos, {}, LabelFilter.empty(), default_branches,
             release_settings, account, pdb, cache)

--- a/server/athenian/api/controllers/miners/jira/issue.py
+++ b/server/athenian/api/controllers/miners/jira/issue.py
@@ -532,9 +532,3 @@ def resolve_work_began_and_resolved(issue_work_began: Optional[np.datetime64],
             (issue_resolved != issue_resolved or issue_resolved is None):
         return work_began, None
     return work_began, max(issue_resolved, prs_released)
-
-
-# TODO: these have to be removed, these are here just for keeping backward-compatibility
-# without the need to re-write already all the places these functions are called
-load_pr_jira_mapping = PullRequestJiraMapper.load_pr_jira_mapping
-append_pr_jira_mapping = PullRequestJiraMapper.append_pr_jira_mapping

--- a/server/athenian/api/controllers/pagination_controller.py
+++ b/server/athenian/api/controllers/pagination_controller.py
@@ -4,7 +4,7 @@ import numpy as np
 from athenian.api.async_utils import gather
 from athenian.api.balancing import weight
 from athenian.api.controllers.filter_controller import resolve_filter_prs_parameters
-from athenian.api.controllers.miners.github.branches import extract_branches
+from athenian.api.controllers.miners.github.branches import BranchMiner
 from athenian.api.controllers.miners.github.precomputed_prs import \
     load_precomputed_done_timestamp_filters
 from athenian.api.controllers.miners.github.pull_request import PullRequestMiner
@@ -28,7 +28,7 @@ async def paginate_prs(request: AthenianWebRequest, body: dict) -> web.Response:
     repos, _, _, participants, labels, jira, settings, prefixer, meta_ids = \
         await resolve_filter_prs_parameters(filt.request, request)
     prefixer.cancel()
-    branches, default_branches = await extract_branches(
+    branches, default_branches = await BranchMiner.extract_branches(
         repos, meta_ids, request.mdb, request.cache)
     # we ignore the ambiguous PRs, thus producing a pessimistic prediction (that's OK)
     done_ats, _ = await load_precomputed_done_timestamp_filters(

--- a/server/athenian/api/controllers/settings_controller.py
+++ b/server/athenian/api/controllers/settings_controller.py
@@ -11,7 +11,7 @@ from athenian.api.auth import disable_default_user
 from athenian.api.controllers.account import get_metadata_account_ids, get_user_account_status
 from athenian.api.controllers.jira import ALLOWED_USER_TYPES, get_jira_id, \
     load_jira_identity_mapping_sentinel
-from athenian.api.controllers.miners.github.branches import extract_branches
+from athenian.api.controllers.miners.github.branches import BranchMiner
 from athenian.api.controllers.settings import ReleaseMatch, Settings
 from athenian.api.models.metadata.github import User as GitHubUser
 from athenian.api.models.metadata.jira import Project, User as JIRAUser
@@ -36,7 +36,7 @@ async def list_release_match_settings(request: AthenianWebRequest, id: int) -> w
         k: ReleaseMatchSetting.from_dataclass(m).to_dict()
         for k, m in settings.prefixed.items()
     }
-    _, default_branches = await extract_branches(
+    _, default_branches = await BranchMiner.extract_branches(
         settings.native, meta_ids, request.mdb, request.cache)
     for repo, name in default_branches.items():
         model[settings.prefixed_for_native(repo)]["default_branch"] = name

--- a/server/athenian/api/hacks/heat_cache.py
+++ b/server/athenian/api/hacks/heat_cache.py
@@ -31,7 +31,7 @@ from athenian.api.controllers.invitation_controller import fetch_github_installa
 from athenian.api.controllers.jira import match_jira_identities
 from athenian.api.controllers.miners.filters import JIRAFilter, LabelFilter
 from athenian.api.controllers.miners.github.bots import Bots
-from athenian.api.controllers.miners.github.branches import extract_branches
+from athenian.api.controllers.miners.github.branches import BranchMiner
 from athenian.api.controllers.miners.github.contributors import mine_contributors
 from athenian.api.controllers.miners.github.dag_accelerated import searchsorted_inrange
 from athenian.api.controllers.miners.github.precomputed_prs import \
@@ -185,7 +185,8 @@ def main():
                      reposet.id, reposet.owner_id, len(repos))
             try:
                 log.info("Mining all the releases")
-                branches, default_branches = await extract_branches(repos, meta_ids, mdb, None)
+                branches, default_branches = await BranchMiner.extract_branches(
+                    repos, meta_ids, mdb, None)
                 releases, _, _ = await mine_releases(
                     repos, {}, branches, default_branches, no_time_from, time_to,
                     JIRAFilter.empty(), settings, prefixer, reposet.owner_id, meta_ids,

--- a/server/athenian/api/hacks/push_copy_releases.py
+++ b/server/athenian/api/hacks/push_copy_releases.py
@@ -14,7 +14,7 @@ import athenian
 from athenian.api.__main__ import check_schema_versions, compose_db_options, setup_context
 from athenian.api.controllers.account import get_metadata_account_ids
 from athenian.api.controllers.miners.github.branches import BranchMiner
-from athenian.api.controllers.miners.github.release_load import load_releases
+from athenian.api.controllers.miners.github.release_load import ReleaseLoader
 from athenian.api.controllers.prefixer import Prefixer
 from athenian.api.controllers.settings import Settings
 from athenian.api.db import ParallelDatabase
@@ -97,7 +97,7 @@ def main():
             args.repos, meta_ids, mdb, None)
         now = datetime.now(timezone.utc)
         log.info("Loading releases in %s", args.repos)
-        releases, _ = await load_releases(
+        releases, _ = await ReleaseLoader.load_releases(
             args.repos, branches, default_branches, now - timedelta(days=365 * 2), now,
             settings, args.account, meta_ids, mdb, pdb, rdb, None)
         inserted = []

--- a/server/athenian/api/hacks/push_copy_releases.py
+++ b/server/athenian/api/hacks/push_copy_releases.py
@@ -13,7 +13,7 @@ from sqlalchemy.dialects.postgresql import insert as postgres_insert
 import athenian
 from athenian.api.__main__ import check_schema_versions, compose_db_options, setup_context
 from athenian.api.controllers.account import get_metadata_account_ids
-from athenian.api.controllers.miners.github.branches import extract_branches
+from athenian.api.controllers.miners.github.branches import BranchMiner
 from athenian.api.controllers.miners.github.release_load import load_releases
 from athenian.api.controllers.prefixer import Prefixer
 from athenian.api.controllers.settings import Settings
@@ -93,7 +93,8 @@ def main():
         settings = await Settings \
             .from_account(args.account, sdb, mdb, None, None) \
             .list_release_matches(prefixer.prefix_repo_names(args.repos))
-        branches, default_branches = await extract_branches(args.repos, meta_ids, mdb, None)
+        branches, default_branches = await BranchMiner.extract_branches(
+            args.repos, meta_ids, mdb, None)
         now = datetime.now(timezone.utc)
         log.info("Loading releases in %s", args.repos)
         releases, _ = await load_releases(

--- a/server/athenian/api/preloading/cache.py
+++ b/server/athenian/api/preloading/cache.py
@@ -467,6 +467,7 @@ def get_memory_cache_options() -> Dict[str, Dict[str, Dict[str, List[Instrumente
                     "key": "acc_id",
                 },
                 "cols": [
+                    PrecomputedRelease.id,
                     PrecomputedRelease.release_match,
                     PrecomputedRelease.repository_full_name,
                     PrecomputedRelease.published_at,
@@ -476,6 +477,9 @@ def get_memory_cache_options() -> Dict[str, Dict[str, Dict[str, List[Instrumente
                     PrecomputedRelease.acc_id,
                     PrecomputedRelease.repository_full_name,
                     PrecomputedRelease.release_match,
+                ],
+                "identifier_cols": [
+                    PrecomputedRelease.id,
                 ],
             },
             PCID.releases_match_timespan.value: {

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -292,7 +292,13 @@ def slack():
 
 
 @pytest.fixture(scope="function")
-async def app(metadata_db, state_db, precomputed_db, persistentdata_db, slack) -> AthenianApp:
+def with_preloading():
+    return os.getenv("WITH_PRELOADING", "0") == "1"
+
+
+@pytest.fixture(scope="function")
+async def app(metadata_db, state_db, precomputed_db, persistentdata_db, slack,
+              with_preloading) -> AthenianApp:
     logging.getLogger("connexion.operation").setLevel("WARNING")
     app = AthenianApp(mdb_conn=metadata_db,
                       sdb_conn=state_db,
@@ -305,7 +311,7 @@ async def app(metadata_db, state_db, precomputed_db, persistentdata_db, slack) -
                       client_max_size=256 * 1024,
                       max_load=15,
                       with_pdb_schema_checks=False)
-    if os.getenv("WITH_PRELOADING", "0") == "1":
+    if with_preloading:
         app.on_dbs_connected(MemoryCachePreloader(None, False).preload)
     await app.ready()
     return app

--- a/server/tests/controllers/conftest.py
+++ b/server/tests/controllers/conftest.py
@@ -9,14 +9,12 @@ import pytest
 from sqlalchemy import delete, insert, select
 
 from athenian.api.controllers.features.entries import MetricEntriesCalculator
-from athenian.api.controllers.miners.github.branches import BranchMiner
 from athenian.api.controllers.miners.github.commit import _empty_dag, _fetch_commit_history_edges
 from athenian.api.controllers.miners.github.dag_accelerated import join_dags
 from athenian.api.controllers.miners.types import nonemin, PullRequestFacts
 from athenian.api.controllers.prefixer import Prefixer
 from athenian.api.controllers.settings import default_branch_alias, ReleaseMatch, \
     ReleaseMatchSetting, ReleaseSettings
-from athenian.api.experiments.preloading.entries import PreloadedBranchMiner
 from athenian.api.models.metadata.github import Branch
 from athenian.api.models.state.models import JIRAProjectSetting, MappedJIRAIdentity
 from athenian.api.typing_utils import wraps
@@ -61,8 +59,7 @@ _branches = None
 
 
 @pytest.fixture(scope="function")
-async def branches(mdb, with_preloading):
-    branch_miner = PreloadedBranchMiner if with_preloading else BranchMiner
+async def branches(mdb, branch_miner):
     global _branches
     if _branches is None:
         _branches, _ = await branch_miner.extract_branches(["src-d/go-git"], (6366825,), mdb, None)

--- a/server/tests/controllers/conftest.py
+++ b/server/tests/controllers/conftest.py
@@ -9,13 +9,14 @@ import pytest
 from sqlalchemy import delete, insert, select
 
 from athenian.api.controllers.features.entries import MetricEntriesCalculator
-from athenian.api.controllers.miners.github.branches import extract_branches
+from athenian.api.controllers.miners.github.branches import BranchMiner
 from athenian.api.controllers.miners.github.commit import _empty_dag, _fetch_commit_history_edges
 from athenian.api.controllers.miners.github.dag_accelerated import join_dags
 from athenian.api.controllers.miners.types import nonemin, PullRequestFacts
 from athenian.api.controllers.prefixer import Prefixer
 from athenian.api.controllers.settings import default_branch_alias, ReleaseMatch, \
     ReleaseMatchSetting, ReleaseSettings
+from athenian.api.experiments.preloading.entries import PreloadedBranchMiner
 from athenian.api.models.metadata.github import Branch
 from athenian.api.models.state.models import JIRAProjectSetting, MappedJIRAIdentity
 from athenian.api.typing_utils import wraps
@@ -60,10 +61,11 @@ _branches = None
 
 
 @pytest.fixture(scope="function")
-async def branches(mdb):
+async def branches(mdb, with_preloading):
+    branch_miner = PreloadedBranchMiner if with_preloading else BranchMiner
     global _branches
     if _branches is None:
-        _branches, _ = await extract_branches(["src-d/go-git"], (6366825,), mdb, None)
+        _branches, _ = await branch_miner.extract_branches(["src-d/go-git"], (6366825,), mdb, None)
     return _branches
 
 

--- a/server/tests/controllers/miners/github/test_branches.py
+++ b/server/tests/controllers/miners/github/test_branches.py
@@ -3,49 +3,60 @@ from random import random
 import pytest
 from sqlalchemy import delete, insert, select, update
 
-from athenian.api.controllers.miners.github.branches import extract_branches
+from athenian.api.controllers.miners.github.branches import BranchMiner
 from athenian.api.defer import wait_deferred, with_defer
+from athenian.api.experiments.preloading.entries import PreloadedBranchMiner
 from athenian.api.models.metadata.github import Branch
 
 
-async def test_extract_branches_zero(mdb):
-    branches, defaults = await extract_branches(["src-d/gitbase"], (6366825,), mdb, None)
+async def test_extract_branches_zero(mdb, with_preloading):
+    branch_miner = PreloadedBranchMiner if with_preloading else BranchMiner
+    branches, defaults = await branch_miner.extract_branches(
+        ["src-d/gitbase"], (6366825,), mdb, None)
     assert branches.empty
     assert defaults == {"src-d/gitbase": "master"}
     async with mdb.connection() as conn:
-        branches, defaults = await extract_branches(["src-d/gitbase"], (6366825,), conn, None)
+        branches, defaults = await branch_miner.extract_branches(
+            ["src-d/gitbase"], (6366825,), conn, None)
         assert branches.empty
         assert defaults == {"src-d/gitbase": "master"}
 
 
-async def test_extract_branches_trash(mdb):
-    branches, defaults = await extract_branches(["src-d/whatever"], (6366825,), mdb, None)
+async def test_extract_branches_trash(mdb, with_preloading):
+    branch_miner = PreloadedBranchMiner if with_preloading else BranchMiner
+    branches, defaults = await branch_miner.extract_branches(
+        ["src-d/whatever"], (6366825,), mdb, None)
     assert branches.empty
     assert defaults == {"src-d/whatever": "master"}
 
 
 @with_defer
-async def test_extract_branches_cache(mdb, cache):
-    branches, defaults = await extract_branches(["src-d/go-git"], (6366825,), mdb, cache)
+async def test_extract_branches_cache(mdb, cache, with_preloading):
+    branch_miner = PreloadedBranchMiner if with_preloading else BranchMiner
+    branches, defaults = await branch_miner.extract_branches(
+        ["src-d/go-git"], (6366825,), mdb, cache)
     await wait_deferred()
     assert not branches.empty
     assert defaults == {"src-d/go-git": "master"}
-    branches, defaults = await extract_branches(["src-d/go-git"], (6366825,), None, cache)
+    branches, defaults = await branch_miner.extract_branches(
+        ["src-d/go-git"], (6366825,), None, cache)
     await wait_deferred()
     assert not branches.empty
     assert defaults == {"src-d/go-git": "master"}
     with pytest.raises(AttributeError):
-        await extract_branches(["src-d/go-git", "src-d/gitbase"], (6366825,), None, cache)
+        await branch_miner.extract_branches(
+            ["src-d/go-git", "src-d/gitbase"], (6366825,), None, cache)
 
 
 @pytest.mark.flaky(reruns=5, reruns_delay=0.1 + random())
-async def test_extract_branches_main(mdb):
+async def test_extract_branches_main(mdb, with_preloading):
+    branch_miner = PreloadedBranchMiner if with_preloading else BranchMiner
     await mdb.execute(update(Branch).where(Branch.branch_name == "master").values({
         Branch.is_default: False,
         Branch.branch_name: "main",
     }))
     try:
-        _, defaults = await extract_branches(["src-d/go-git"], (6366825,), mdb, None)
+        _, defaults = await branch_miner.extract_branches(["src-d/go-git"], (6366825,), mdb, None)
         assert defaults == {"src-d/go-git": "main"}
     finally:
         await mdb.execute(update(Branch).where(Branch.branch_name == "main").values({
@@ -55,13 +66,14 @@ async def test_extract_branches_main(mdb):
 
 
 @pytest.mark.flaky(reruns=5, reruns_delay=0.1 + random())
-async def test_extract_branches_max_date(mdb):
+async def test_extract_branches_max_date(mdb, with_preloading):
+    branch_miner = PreloadedBranchMiner if with_preloading else BranchMiner
     await mdb.execute(update(Branch).where(Branch.branch_name == "master").values({
         Branch.is_default: False,
         Branch.branch_name: "whatever_it_takes",
     }))
     try:
-        _, defaults = await extract_branches(["src-d/go-git"], (6366825,), mdb, None)
+        _, defaults = await branch_miner.extract_branches(["src-d/go-git"], (6366825,), mdb, None)
         assert defaults == {"src-d/go-git": "whatever_it_takes"}
     finally:
         await mdb.execute(update(Branch).where(Branch.branch_name == "whatever_it_takes").values({
@@ -71,7 +83,8 @@ async def test_extract_branches_max_date(mdb):
 
 
 @pytest.mark.flaky(reruns=5, reruns_delay=0.1 + random())
-async def test_extract_branches_only_one(mdb):
+async def test_extract_branches_only_one(mdb, with_preloading):
+    branch_miner = PreloadedBranchMiner if with_preloading else BranchMiner
     branches = await mdb.fetch_all(select([Branch]).where(Branch.branch_name != "master"))
     await mdb.execute(update(Branch).where(Branch.branch_name == "master").values({
         Branch.is_default: False,
@@ -80,7 +93,8 @@ async def test_extract_branches_only_one(mdb):
     try:
         await mdb.execute(delete(Branch).where(Branch.branch_name != "whatever_it_takes"))
         try:
-            _, defaults = await extract_branches(["src-d/go-git"], (6366825,), mdb, None)
+            _, defaults = await branch_miner.extract_branches(
+                ["src-d/go-git"], (6366825,), mdb, None)
             assert defaults == {"src-d/go-git": "whatever_it_takes"}
         finally:
             for branch in branches:

--- a/server/tests/controllers/miners/github/test_precomputed_prs.py
+++ b/server/tests/controllers/miners/github/test_precomputed_prs.py
@@ -21,7 +21,7 @@ from athenian.api.controllers.miners.github.precomputed_prs import \
     store_merged_unreleased_pull_request_facts, store_open_pull_request_facts, \
     store_precomputed_done_facts, update_unreleased_prs
 from athenian.api.controllers.miners.github.release_load import ReleaseLoader
-from athenian.api.controllers.miners.github.release_match import map_prs_to_releases
+from athenian.api.controllers.miners.github.release_match import PullRequestToReleaseMapper
 from athenian.api.controllers.miners.github.released_pr import matched_by_column, \
     new_released_prs_df
 from athenian.api.controllers.miners.types import MinedPullRequest, PRParticipationKind, \
@@ -695,7 +695,7 @@ async def test_discover_update_unreleased_prs_released(
         time_to,
         release_match_setting_tag,
         1, (6366825,), mdb, pdb, rdb, None)
-    released_prs, _, _ = await map_prs_to_releases(
+    released_prs, _, _ = await PullRequestToReleaseMapper.map_prs_to_releases(
         prs, releases, matched_bys, pd.DataFrame(columns=[Branch.commit_id.key]), {}, time_to, dag,
         release_match_setting_tag, 1, (6366825,), mdb, pdb, None)
     await wait_deferred()
@@ -737,7 +737,7 @@ async def test_discover_update_unreleased_prs_exclude_inactive(
         time_to,
         release_match_setting_tag,
         1, (6366825,), mdb, pdb, rdb, None)
-    released_prs, _, _ = await map_prs_to_releases(
+    released_prs, _, _ = await PullRequestToReleaseMapper.map_prs_to_releases(
         prs, releases, matched_bys, pd.DataFrame(columns=[Branch.commit_id.key]), {}, time_to, dag,
         release_match_setting_tag, 1, (6366825,), mdb, pdb, None)
     await wait_deferred()
@@ -803,7 +803,7 @@ async def test_discover_old_merged_unreleased_prs_smoke(
         release_match_setting_tag, 1, (6366825,), mdb, pdb, rdb, cache)
     await wait_deferred()
     unreleased_prs["dead"] = False
-    released_prs, _, _ = await map_prs_to_releases(
+    released_prs, _, _ = await PullRequestToReleaseMapper.map_prs_to_releases(
         unreleased_prs, releases, matched_bys, pd.DataFrame(columns=[Branch.commit_id.key]), {},
         unreleased_time_to, dag, release_match_setting_tag, 1, (6366825,), mdb, pdb, cache)
     await wait_deferred()

--- a/server/tests/controllers/miners/github/test_precomputed_prs.py
+++ b/server/tests/controllers/miners/github/test_precomputed_prs.py
@@ -940,7 +940,8 @@ async def test_store_merged_unreleased_pull_request_facts_smoke(
 
 @with_defer
 async def test_store_open_pull_request_facts_smoke(
-        mdb, pdb, rdb, release_match_setting_tag, open_prs_facts_loader):
+        mdb, pdb, rdb, release_match_setting_tag, open_prs_facts_loader,
+        with_preloading_enabled):
     prs, dfs, facts, _ = await _fetch_pull_requests(
         {"src-d/go-git": set(range(1000, 1010))},
         release_match_setting_tag, 1, (6366825,), mdb, pdb, rdb, None)
@@ -966,6 +967,8 @@ async def test_store_open_pull_request_facts_smoke(
         true_dict[pr.pr[PullRequest.node_id.key]] = f
     dfs.prs[PullRequest.closed_at.key] = None
     await store_open_pull_request_facts(zip(prs, samples), 1, pdb)
+    if with_preloading_enabled:
+        await pdb.cache.refresh()
     ghoprf = GitHubOpenPullRequestFacts
     rows = await pdb.fetch_all(select([ghoprf]))
     assert len(rows) == 10

--- a/server/tests/controllers/miners/github/test_release.py
+++ b/server/tests/controllers/miners/github/test_release.py
@@ -31,7 +31,8 @@ from athenian.api.defer import wait_deferred, with_defer
 from athenian.api.models.metadata.github import Branch, NodeCommit, PullRequest, \
     PullRequestLabel, Release
 from athenian.api.models.persistentdata.models import ReleaseNotification
-from athenian.api.models.precomputed.models import GitHubCommitHistory
+from athenian.api.models.precomputed.models import GitHubCommitHistory, \
+    GitHubRelease as PrecomputedRelease
 from tests.controllers.test_filter_controller import force_push_dropped_go_git_pr_numbers
 
 
@@ -1394,6 +1395,16 @@ async def test_precomputed_releases_low_level(
         {ReleaseMatch(settings_index): {["master", ".*"][settings_index]: ["src-d/go-git"]}},
         time_from, time_to, 1, pdb)
     if with_preloading_enabled:
+        # Currently, due to preloading being applied to only a subset of endpoints, some
+        # columns are not preloaded, so they're missing here. Once preloading is extended
+        # to other endpoints, these columns will be needed and they'll be added in the options
+        # defined in `athenian.api.preloading.cache`.
+        # Once it will happen, this test will fail and we can just temove this `if` branch.
+        missing_prels_columns = [PrecomputedRelease.repository_node_id, PrecomputedRelease.author,
+                                 PrecomputedRelease.name, PrecomputedRelease.tag,
+                                 PrecomputedRelease.url, PrecomputedRelease.sha,
+                                 PrecomputedRelease.commit_id]
+        assert all(col not in prels.columns for col in missing_prels_columns)
         cols = set(releases.columns).intersection(prels.columns)
         releases, prels = releases[cols], prels[cols]
     else:
@@ -1422,6 +1433,16 @@ async def test_precomputed_releases_ambiguous(
          ReleaseMatch.branch: {"master": ["src-d/go-git"]}},
         time_from, time_to, 1, pdb)
     if with_preloading_enabled:
+        # Currently, due to preloading being applied to only a subset of endpoints, some
+        # columns are not preloaded, so they're missing here. Once preloading is extended
+        # to other endpoints, these columns will be needed and they'll be added in the options
+        # defined in `athenian.api.preloading.cache`.
+        # Once it will happen, this test will fail and we can just temove this `if` branch.
+        missing_prels_columns = [PrecomputedRelease.repository_node_id, PrecomputedRelease.author,
+                                 PrecomputedRelease.name, PrecomputedRelease.tag,
+                                 PrecomputedRelease.url, PrecomputedRelease.sha,
+                                 PrecomputedRelease.commit_id]
+        assert all(col not in prels.columns for col in missing_prels_columns)
         cols = set(releases_tag.columns).intersection(prels.columns)
         releases_tag, prels = releases_tag[cols], prels[cols]
     else:


### PR DESCRIPTION
- Removes all the re-exported backward-compatible class methods as functions in favor of explicit call,
- All tests previously calling the re-exported functions are now calling the corresponding class method, preloaded or not, depending on the `with_preloading` fixture,
- Adds miners to CI preloading tests.