### PR TITLE
Preloading fixes

### DIFF
--- a/server/athenian/api/controllers/calculator_selector.py
+++ b/server/athenian/api/controllers/calculator_selector.py
@@ -60,7 +60,7 @@ async def _get_calculator_for_account(
                 variation=variation, base_module=base_module,
             )
         except CalculatorNotReadyException:
-            variation = "default"
+            variation = None
             calculator = make_calculator(
                 account_id, meta_ids, mdb, pdb, rdb, cache,
                 variation=variation, base_module=base_module,

--- a/server/athenian/api/experiments/preloading/entries.py
+++ b/server/athenian/api/experiments/preloading/entries.py
@@ -631,6 +631,6 @@ class MetricEntriesCalculator(OriginalMetricEntriesCalculator):
     def is_ready_for(self, account: int, meta_ids: Tuple[int, ...]) -> bool:
         """Check whether the calculator is ready for the given account and meta ids."""
         return (
-            all(self._mdb.cache.is_shard_available(m_id) for m_id in meta_ids) and
-            self._pdb.cache.is_shard_available(account)
+            self._mdb.cache.is_account_loaded(account) and
+            self._pdb.cache.is_account_loaded(account)
         )


### PR DESCRIPTION
In [this PR](https://github.com/athenianco/athenian-api/pull/1548) I implemented a check that consists in ensuring that the data for a given account and/or GH installation id are loaded in memory in order to use preloading metrics calculator.

When testing on `mirror` environment, I realized that this check is not reliable as it was causing some false negatives. For example, some data related to the JIRA mapping were missing because of an account without JIRA data. This was causing the API to think that the data were not preloaded when actually the missing data is expected.

I fixed by tracking directly what are the enabled accounts as loaded in the latest `refresh`.