### PR TITLE
[DEV-3831] validate responses using schema during tests

### DIFF
--- a/server/athenian/api/especifico.py
+++ b/server/athenian/api/especifico.py
@@ -227,7 +227,8 @@ class AthenianApp(especifico.AioHttpApp):
                  mandrill: Optional[MandrillClient] = None,
                  with_pdb_schema_checks: bool = True,
                  segment: Optional[SegmentClient] = None,
-                 google_analytics: Optional[str] = ""):
+                 google_analytics: Optional[str] = "",
+                 validate_responses: bool = False):
         """
         Initialize the underlying especifico -> aiohttp application.
 
@@ -252,6 +253,7 @@ class AthenianApp(especifico.AioHttpApp):
         :param with_pdb_schema_checks: Enable or disable periodic pdb schema version checks.
         :param segment: User action tracker.
         :param google_analytics: Google Analytics tag to track Swagger UI.
+        :param validate_responses: validate responses bodies against spec schema
         """
         options = {"swagger_ui": ui}
         specification_dir = str(Path(__file__).parent / "openapi")
@@ -306,6 +308,7 @@ class AthenianApp(especifico.AioHttpApp):
                     "validatorUrl": "null, filter: true",
                 },
             },
+            validate_responses=validate_responses,
         )
         GraphQL(align.create_graphql_schema()).attach(self.app, "/align", middlewares)
         if kms_cls is not None:

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -2,3 +2,6 @@
 requires = ["setuptools!=60.6.0", "wheel", "Cython", "numpy==1.22.3"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+markers = [
+    "app_validate_responses",
+]

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -367,7 +367,7 @@ async def app(metadata_db, state_db, precomputed_db, persistentdata_db, slack,
 
     validate_responses_mark = request.node.get_closest_marker("app_validate_responses")
     if validate_responses_mark is None:
-        validate_responses = False
+        validate_responses = True
     else:
         validate_responses = validate_responses_mark.args[0]
 

--- a/server/tests/controllers/test_events_controller.py
+++ b/server/tests/controllers/test_events_controller.py
@@ -217,6 +217,8 @@ async def test_notify_release_default_user(client, headers, sdb):
     assert response.status == 403
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.parametrize("devenv", [False, True])
 @freeze_time("2020-01-01")
 async def test_clear_precomputed_event_releases_smoke(
@@ -271,6 +273,8 @@ async def test_clear_precomputed_event_releases_smoke(
         assert len(await pdb.fetch_all(select([table]))) == n, table
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @freeze_time("2020-01-01")
 async def test_clear_precomputed_deployments_smoke(client, headers, pdb, disable_default_user):
     await pdb.execute(insert(GitHubDeploymentFacts).values(GitHubDeploymentFacts(
@@ -296,6 +300,8 @@ async def test_clear_precomputed_deployments_smoke(client, headers, pdb, disable
     assert len(row[GitHubDeploymentFacts.data.name]) > 1
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.parametrize("status, body", [
     (200, {"account": 1, "repositories": ["github.com/src-d/go-git"], "targets": []}),
     (400, {"account": 1, "repositories": ["github.com/src-d/go-git"], "targets": ["wrong"]}),
@@ -311,6 +317,8 @@ async def test_clear_precomputed_events_nasty_input(
     assert response.status == status
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.parametrize("ref, vhash", [
     ("4.2.0", "y9c5A0Df"),
     ("v4.2.0", "y9c5A0Df"),
@@ -396,6 +404,8 @@ async def test_notify_deployment_smoke(
     }
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_notify_deployment_duplicate(client, headers, token, disable_default_user):
     body = [{
         "components": [{

--- a/server/tests/controllers/test_filter_controller.py
+++ b/server/tests/controllers/test_filter_controller.py
@@ -239,6 +239,8 @@ async def test_filter_repositories_logical(
     assert repos == ["github.com/src-d/go-git/alpha"]
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_contributors
 @pytest.mark.parametrize("in_", [{}, {"in": []}])
 async def test_filter_contributors_no_repos(client, headers, in_):
@@ -250,7 +252,8 @@ async def test_filter_contributors_no_repos(client, headers, in_):
     }
     response = await client.request(
         method="POST", path="/v1/filter/contributors", headers=headers, json=body)
-    contribs = json.loads((await response.read()).decode("utf-8"))
+    assert response.status == 200
+    contribs = await response.json()
     assert len(contribs) == 202
     assert len(set(c["login"] for c in contribs)) == len(contribs)
     assert all(c["login"].startswith("github.com/") for c in contribs)
@@ -260,10 +263,12 @@ async def test_filter_contributors_no_repos(client, headers, in_):
     response = await client.request(
         method="POST", path="/v1/filter/contributors", headers=headers, json=body)
     assert response.status == 200
-    contribs = json.loads((await response.read()).decode("utf-8"))
+    contribs = await response.json()
     assert contribs == []
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_contributors
 async def test_filter_contributors(client, headers):
     body = {
@@ -275,7 +280,8 @@ async def test_filter_contributors(client, headers):
     }
     response = await client.request(
         method="POST", path="/v1/filter/contributors", headers=headers, json=body)
-    contribs = json.loads((await response.read()).decode("utf-8"))
+    assert response.status == 200
+    contribs = await response.json()
     assert len(contribs) == 199
     assert len(set(c["login"] for c in contribs)) == len(contribs)
     assert all(c["login"].startswith("github.com/") for c in contribs)
@@ -294,10 +300,13 @@ async def test_filter_contributors(client, headers):
     body["in"] = ["github.com/src-d/gitbase"]
     response = await client.request(
         method="POST", path="/v1/filter/contributors", headers=headers, json=body)
-    contribs = json.loads((await response.read()).decode("utf-8"))
+    assert response.status == 200
+    contribs = await response.json()
     assert contribs == []
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_contributors
 async def test_filter_contributors_merger_only(client, headers):
     body = {
@@ -310,7 +319,8 @@ async def test_filter_contributors_merger_only(client, headers):
     }
     response = await client.request(
         method="POST", path="/v1/filter/contributors", headers=headers, json=body)
-    mergers = json.loads((await response.read()).decode("utf-8"))
+    assert response.status == 200
+    mergers = await response.json()
     mergers_logins = {c["login"] for c in mergers}
 
     assert len(mergers) == 8
@@ -328,6 +338,8 @@ async def test_filter_contributors_merger_only(client, headers):
     assert mergers_logins == expected_mergers
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.flaky(reruns=3, reruns_delay=1)
 @pytest.mark.filter_contributors
 async def test_filter_contributors_with_empty_and_full_roles(client, headers):
@@ -357,6 +369,8 @@ async def test_filter_contributors_with_empty_and_full_roles(client, headers):
             sorted(parsed_all_roles, key=itemgetter("login")))
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_contributors
 @pytest.mark.parametrize("account, date_to, in_, code",
                          [(3, "2020-01-23", None, 404),
@@ -390,6 +404,8 @@ def filter_prs_single_cache():
     return fc
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_pull_requests
 @pytest.mark.parametrize("stage",
                          sorted(set(PullRequestStage) - {PullRequestStage.RELEASE_IGNORED}))
@@ -412,6 +428,8 @@ async def test_filter_prs_single_stage(
                                 datetime(year=2020, month=4, day=23, tzinfo=timezone.utc))
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_pull_requests
 @with_only_master_branch
 async def test_filter_prs_stage_deployed(
@@ -434,6 +452,8 @@ async def test_filter_prs_stage_deployed(
     assert len(prs.data) == 418
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_pull_requests
 @pytest.mark.parametrize("event", sorted(PullRequestEvent))
 @with_only_master_branch
@@ -455,6 +475,8 @@ async def test_filter_prs_single_event(
                                 datetime(year=2020, month=4, day=23, tzinfo=timezone.utc))
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_pull_requests
 @with_only_master_branch
 async def test_filter_prs_event_deployed(
@@ -477,6 +499,8 @@ async def test_filter_prs_event_deployed(
     assert len(prs.data) == 418
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_pull_requests
 @with_only_master_branch
 async def test_filter_prs_no_stages(client, headers, mdb_rw):
@@ -505,6 +529,8 @@ async def test_filter_prs_no_stages(client, headers, mdb_rw):
     assert response.status == 400
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_pull_requests
 @with_only_master_branch
 async def test_filter_prs_shot_updated(
@@ -532,6 +558,8 @@ async def test_filter_prs_shot_updated(
     # it is 75 without the constraints
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_pull_requests
 async def test_filter_prs_labels_include(client, headers):
     body = {
@@ -553,6 +581,8 @@ async def test_filter_prs_labels_include(client, headers):
         assert "bug" in {label.name for label in pr.labels}
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_pull_requests
 @pytest.mark.parametrize("timezone, must_match", [(120, True), (60, True), (0, False)])
 async def test_filter_prs_merged_timezone(client, headers, timezone, must_match):
@@ -577,6 +607,8 @@ async def test_filter_prs_merged_timezone(client, headers, timezone, must_match)
     assert matched == must_match
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_pull_requests
 @pytest.mark.parametrize("timezone, must_match", [(-7 * 60, False), (-8 * 60, True)])
 async def test_filter_prs_created_timezone(client, headers, timezone, must_match):
@@ -601,6 +633,8 @@ async def test_filter_prs_created_timezone(client, headers, timezone, must_match
     assert matched == must_match
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_filter_prs_event_releases(client, headers, with_event_releases):
     body = {
         "date_from": "2018-10-13",
@@ -618,6 +652,8 @@ async def test_filter_prs_event_releases(client, headers, with_event_releases):
     assert len(prs.data) == 37
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_filter_prs_deployments_missing_env(
         client, headers, precomputed_deployments, detect_deployments):
     body = {
@@ -642,6 +678,8 @@ async def test_filter_prs_deployments_missing_env(
         assert "deployed" not in pr.stages_time_machine
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_filter_prs_deployments_with_env(
         client, headers, precomputed_deployments, detect_deployments):
     body = {
@@ -674,6 +712,8 @@ async def test_filter_prs_deployments_with_env(
     assert deps == 37
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_filter_prs_jira(client, headers, app, filter_prs_single_cache):
     app.app[CACHE_VAR_NAME] = filter_prs_single_cache
     body = {
@@ -732,6 +772,8 @@ async def test_filter_prs_jira_disabled_projects(client, headers, disabled_dev):
     assert len(prs.data) == 0
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_pull_requests
 async def test_filter_prs_logical(
         client, headers, logical_settings_db, release_match_setting_tag_logical_db):
@@ -1149,6 +1191,8 @@ async def test_filter_prs_david_bug(client, headers):
     assert response.status == 200
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_pull_requests
 async def test_filter_prs_developer_filter(client, headers):
     body = {
@@ -1177,6 +1221,8 @@ async def test_filter_prs_developer_filter(client, headers):
         assert passed
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_pull_requests
 async def test_filter_prs_exclude_inactive(client, headers):
     body = {
@@ -1195,6 +1241,8 @@ async def test_filter_prs_exclude_inactive(client, headers):
     assert len(prs.data) == 6
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_pull_requests
 @with_defer
 async def test_filter_prs_release_ignored(
@@ -1344,6 +1392,8 @@ async def test_filter_commits_bypassing_prs_merges(client, headers):
         assert c.committer.email != "noreply@github.com"
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_commits
 @pytest.mark.parametrize("only_default_branch, length", [(True, 375), (False, 450)])
 async def test_filter_commits_bypassing_prs_only_default_branch(
@@ -1433,6 +1483,8 @@ async def test_filter_commits_bypassing_prs_nasty_input(
     assert response.status == code
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_releases
 async def test_filter_releases_by_tag(client, headers):
     body = {
@@ -1493,6 +1545,8 @@ async def test_filter_releases_by_tag(client, headers):
     assert jira_stats == {1: 44}
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_releases
 async def test_filter_releases_by_branch_no_jira(client, headers, client_cache, app, sdb, mdb_rw):
     backup = await mdb_rw.fetch_all(select([Release]))
@@ -1516,6 +1570,8 @@ async def test_filter_releases_by_branch_no_jira(client, headers, client_cache, 
         await mdb_rw.execute(insert(Release).values(backup))
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_releases
 async def test_filter_releases_by_event(client, headers, with_event_releases):
     body = {
@@ -1534,6 +1590,8 @@ async def test_filter_releases_by_event(client, headers, with_event_releases):
     assert len(releases.data[0].prs) == 391
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_releases
 async def test_filter_releases_by_participants(client, headers):
     body = {
@@ -1584,6 +1642,8 @@ async def test_filter_releases_nasty_input(client, headers, account, date_to, in
     assert response.status == code
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_releases
 async def test_filter_releases_by_jira(client, headers):
     body = {
@@ -1620,6 +1680,8 @@ async def test_filter_releases_by_labels(client, headers):
     assert len(releases.data) == 3
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_releases
 @with_defer
 async def test_filter_releases_deployments(
@@ -1663,6 +1725,8 @@ async def test_filter_releases_deployments(
     assert releases.data[0].deployments == ["Dummy deployment"]
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_get_prs_smoke(client, headers):
     body = {
         "account": 1,
@@ -1703,6 +1767,8 @@ async def test_get_prs_nasty_input(client, headers, account, repo, numbers, stat
     assert response.status == status, response_body
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @with_defer
 async def test_get_prs_deployments(
         client, headers, mdb, pdb, rdb, release_match_setting_tag, branches, default_branches,
@@ -1751,6 +1817,8 @@ async def test_get_prs_deployments(
     }
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_labels
 async def test_filter_labels_smoke(client, headers):
     body = {
@@ -1769,6 +1837,8 @@ async def test_filter_labels_smoke(client, headers):
     assert labels[0].used_prs == 7
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_labels
 @pytest.mark.parametrize("account, repos, status",
                          [(1, ["github.com/whatever/else"], 403),
@@ -2142,6 +2212,8 @@ async def test_get_releases_nasty_input(client, headers, account, repo, names, c
     assert response.status == code, response_body
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.flaky(reruns=3)
 async def test_diff_releases_smoke(client, headers):
     body = {
@@ -2240,6 +2312,8 @@ async def test_diff_releases_nasty_input(client, headers, account, repo, old, ne
             assert response_body["data"] == [[{"old": old, "new": new, "releases": []}]]
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_filter_check_runs_smoke(client, headers):
     body = {
         "account": 1,
@@ -2310,6 +2384,8 @@ async def test_filter_check_runs_smoke(client, headers):
     assert nn_successes_timeline > 0
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_filter_check_runs_no_jira(client, headers, sdb):
     await sdb.execute(delete(AccountJiraInstallation))
     body = {
@@ -2325,6 +2401,8 @@ async def test_filter_check_runs_no_jira(client, headers, sdb):
     assert response.status == 200, response_text
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.parametrize("filters, count", [
     ({"labels_include": ["bug", "plumbing", "enhancement"]}, 4),
     ({"triggered_by": ["github.com/mcuadros"]}, 7),
@@ -2347,6 +2425,8 @@ async def test_filter_check_runs_filters(client, headers, filters, count):
     assert len(check_runs.items) == count
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_filter_check_runs_logical_repos(client, headers, logical_settings_db):
     body = {
         "account": 1,
@@ -2385,6 +2465,8 @@ async def test_filter_check_runs_nasty_input(
     assert response.status == status, response_text
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_filter_deployments_smoke(client, headers):
     body = {
         "account": 1,

--- a/server/tests/controllers/test_histograms_controller.py
+++ b/server/tests/controllers/test_histograms_controller.py
@@ -8,6 +8,8 @@ from athenian.api.models.web import CalculatedPullRequestHistogram, CodeCheckMet
 from athenian.api.serialization import FriendlyJson
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.parametrize(
     "metric, cached, result",
     itertools.chain(zip((PullRequestMetricID.PR_CYCLE_TIME,
@@ -535,6 +537,8 @@ async def test_calc_histogram_code_checks_nasty_input(
     assert response.status == status, "Response body is : " + rbody
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_histogram_code_checks_split(client, headers):
     body = {
         "account": 1,
@@ -595,6 +599,8 @@ async def test_calc_histogram_code_checks_split(client, headers):
     ]
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_histogram_code_checks_elapsed_time_per_concurrency(client, headers):
     body = {
         "account": 1,

--- a/server/tests/controllers/test_integrations_controller.py
+++ b/server/tests/controllers/test_integrations_controller.py
@@ -59,6 +59,8 @@ async def test_match_identities_nasty_input(client, headers, body, code):
     assert response.status == code, "Response body is : " + rbody
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_get_everything_smoke(client, headers, dummy_deployment_label):
     # preheat
     body = {

--- a/server/tests/controllers/test_jira_controller.py
+++ b/server/tests/controllers/test_jira_controller.py
@@ -19,6 +19,8 @@ from athenian.api.models.web import CalculatedJIRAHistogram, CalculatedJIRAMetri
 from athenian.api.serialization import FriendlyJson
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.parametrize("return_, checked", [
     (None, set(JIRAFilterReturn)),
     ([], set(JIRAFilterReturn) - {JIRAFilterReturn.ONLY_FLYING}),
@@ -365,6 +367,8 @@ async def test_filter_jira_epics_deleted(client, headers, ikey, mdb_rw):
         await mdb.execute(update(Issue).where(Issue.key == ikey).values({Issue.is_deleted: False}))
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.parametrize("exclude_inactive, labels, epics, types, users, priorities", [
     [False, 32, 13, [
         JIRAIssueType(name="Bug", count=2,
@@ -447,6 +451,8 @@ async def test_filter_jira_exclude_inactive(
     assert len(model.priorities) == priorities
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_filter_jira_disabled_projects(client, headers, disabled_dev):
     body = {
         "date_from": "2019-10-13",
@@ -464,6 +470,8 @@ async def test_filter_jira_disabled_projects(client, headers, disabled_dev):
     _check_filter_jira_no_dev_project(model)
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_filter_jira_selected_projects(client, headers):
     body = {
         "date_from": "2019-10-13",
@@ -597,6 +605,8 @@ async def test_filter_jira_issue_types_filter(client, headers):
     assert not model.issues
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_filter_jira_issue_prs_comments(client, headers):
     body = {
         "date_from": "2020-09-01",
@@ -626,6 +636,8 @@ async def test_filter_jira_issue_prs_comments(client, headers):
     assert not model.deployments
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_filter_jira_issue_prs_deployments(client, headers, mdb_rw, precomputed_deployments):
     body = {
         "date_from": "2018-09-01",
@@ -675,6 +687,8 @@ async def test_filter_jira_issue_prs_deployments(client, headers, mdb_rw, precom
     }
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_filter_jira_issue_prs_logical(
         client, headers, logical_settings_db, release_match_setting_tag_logical_db):
     body = {
@@ -703,6 +717,8 @@ async def test_filter_jira_issue_prs_logical(
     }
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_filter_jira_issue_only_flying(client, headers):
     body = {
         "date_from": "2020-09-01",
@@ -721,6 +737,8 @@ async def test_filter_jira_issue_only_flying(client, headers):
     assert len(model.issues) == 199
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_filter_jira_issue_disabled(client, headers, mdb_rw):
     ikey = "ENG-303"
     mdb = mdb_rw
@@ -745,6 +763,8 @@ async def test_filter_jira_issue_disabled(client, headers, mdb_rw):
         await mdb.execute(update(Issue).where(Issue.key == ikey).values({Issue.is_deleted: False}))
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_filter_jira_deleted_repositories(client, headers, mdb_rw):
     # DEV-2082
     mdb = mdb_rw
@@ -1097,6 +1117,8 @@ async def test_jira_metrics_counts(client, headers, metric, exclude_inactive, n)
     )]
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.parametrize("metric, value, score, cmin, cmax", [
     (JIRAMetricID.JIRA_LIFE_TIME, "3360382s", 51, "2557907s", "4227690s"),
     (JIRAMetricID.JIRA_LEAD_TIME, "2922288s", 43, "2114455s", "3789853s"),

--- a/server/tests/controllers/test_metrics_controller.py
+++ b/server/tests/controllers/test_metrics_controller.py
@@ -22,6 +22,8 @@ from athenian.api.models.web import CalculatedCodeCheckMetrics, CalculatedDeploy
 from athenian.api.serialization import FriendlyJson
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.parametrize(
     "metric, count", [
         (PullRequestMetricID.PR_WIP_TIME, 51),
@@ -107,6 +109,8 @@ async def test_calc_metrics_prs_smoke(client, metric, count, headers, app, clien
         assert s == count
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_metrics_prs_all_time(client, headers):
     """https://athenianco.atlassian.net/browse/ENG-116"""
     devs = ["github.com/vmarkovtsev", "github.com/mcuadros"]
@@ -223,6 +227,8 @@ async def test_calc_metrics_prs_access_denied(client, headers):
     assert response.status == 403, "Response body is : " + body
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.parametrize(("devs", "date_from"),
                          ([{"with": {}}, "2019-11-28"], [{}, "2018-09-28"]))
 async def test_calc_metrics_prs_empty_devs_tight_date(client, devs, date_from, headers):
@@ -251,6 +257,8 @@ async def test_calc_metrics_prs_empty_devs_tight_date(client, devs, date_from, h
     assert len(cm.calculated[0].values) > 0
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.parametrize("account, date_to, quantiles, lines, in_, code",
                          [(3, "2020-02-22", [0, 1], None, "{1}", 404),
                           (2, "2020-02-22", [0, 1], None, "{1}", 422),
@@ -304,6 +312,8 @@ async def test_calc_metrics_prs_nasty_input(
     assert response.status == code, "Response body is : " + body
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_metrics_prs_reposet(client, headers):
     """Substitute {id} with the real repos."""
     body = {
@@ -330,6 +340,8 @@ async def test_calc_metrics_prs_reposet(client, headers):
     assert cm.calculated[0].for_.repositories == ["{1}"]
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.parametrize("metric, count", [
     (PullRequestMetricID.PR_WIP_COUNT, 596),
     (PullRequestMetricID.PR_REVIEW_COUNT, 434),
@@ -381,6 +393,8 @@ async def test_calc_metrics_prs_counts_sums(client, headers, metric, count):
     assert s == count
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.parametrize("with_bots, values", [
     (False, [[2.461538553237915, None, None, None],
              [2.8358209133148193, 3.8701298236846924, 10.055999755859375, 11.704000473022461],
@@ -425,6 +439,8 @@ async def test_calc_metrics_prs_averages(client, headers, with_bots, values, sdb
     assert [v["values"] for v in body["calculated"][0]["values"]] == values
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_metrics_prs_sizes(client, headers):
     body = {
         "for": [
@@ -471,6 +487,8 @@ async def test_calc_metrics_prs_sizes(client, headers):
     assert values == [[177, 54]]
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_metrics_prs_index_error(client, headers):
     body = {
         "for": [
@@ -496,6 +514,8 @@ async def test_calc_metrics_prs_index_error(client, headers):
     assert response.status == 200
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_metrics_prs_ratio_flow(client, headers):
     """https://athenianco.atlassian.net/browse/ENG-411"""
     body = {
@@ -532,6 +552,8 @@ async def test_calc_metrics_prs_ratio_flow(client, headers):
             "%.3f != %d / %d" % (flow, opened, closed)
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_metrics_prs_exclude_inactive_full_span(client, headers):
     body = {
         "date_from": "2017-01-01",
@@ -555,6 +577,8 @@ async def test_calc_metrics_prs_exclude_inactive_full_span(client, headers):
     assert cm.calculated[0].values[0].values[0] == 6
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_metrics_prs_exclude_inactive_split(client, headers):
     body = {
         "date_from": "2016-12-21",
@@ -580,6 +604,8 @@ async def test_calc_metrics_prs_exclude_inactive_split(client, headers):
     assert cm.calculated[0].values[1].values[0] == 6
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_metrics_prs_filter_authors(client, headers):
     body = {
         "date_from": "2017-01-01",
@@ -606,6 +632,8 @@ async def test_calc_metrics_prs_filter_authors(client, headers):
     assert cm.calculated[0].values[0].values[0] == 1
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_metrics_prs_group_authors(client, headers):
     body = {
         "date_from": "2017-01-01",
@@ -642,6 +670,8 @@ async def test_calc_metrics_prs_group_authors(client, headers):
     assert not cm.calculated[1].for_.with_.author
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_metrics_prs_labels_include(client, headers):
     body = {
         "date_from": "2018-09-01",
@@ -668,6 +698,8 @@ async def test_calc_metrics_prs_labels_include(client, headers):
     assert cm.calculated[0].values[0].values[0] == 6
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_metrics_prs_quantiles(client, headers):
     body = {
         "date_from": "2018-06-01",
@@ -725,6 +757,8 @@ async def test_calc_metrics_prs_quantiles(client, headers):
     assert response.status == 200, "Response body is : " + rbody
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_metrics_prs_jira(client, headers):
     """Metrics over PRs filtered by JIRA properties."""
     body = {
@@ -754,6 +788,8 @@ async def test_calc_metrics_prs_jira(client, headers):
     assert cm.calculated[0].values[0].values[0] == "478544s"
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_metrics_prs_jira_disabled_projects(client, headers, disabled_dev):
     body = {
         "for": [{
@@ -779,6 +815,8 @@ async def test_calc_metrics_prs_jira_disabled_projects(client, headers, disabled
     assert cm.calculated[0].values[0].values[0] is None
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_metrics_prs_jira_custom_projects(client, headers):
     body = {
         "for": [{
@@ -805,6 +843,8 @@ async def test_calc_metrics_prs_jira_custom_projects(client, headers):
     assert cm.calculated[0].values[0].values[0] is None
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_metrics_prs_jira_only_custom_projects(client, headers):
     body = {
         "for": [{
@@ -830,6 +870,8 @@ async def test_calc_metrics_prs_jira_only_custom_projects(client, headers):
     assert cm.calculated[0].values[0].values[0] == 45  # > 400 without JIRA projects
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_metrics_prs_groups_smoke(client, headers):
     """Two repository groups."""
     body = {
@@ -884,6 +926,8 @@ async def test_calc_metrics_prs_groups_nasty(client, headers, repogroups):
     assert response.status == 400, "Response body is : " + body
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_metrics_prs_lines_smoke(client, headers):
     """Two repository groups."""
     body = {
@@ -959,6 +1003,8 @@ async def test_calc_metrics_prs_deployments_no_env(client, headers, metric):
     assert response.status == 400, response.text()
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_metrics_prs_deployments_smoke(client, headers, precomputed_deployments):
     body = {
         "for": [
@@ -986,6 +1032,8 @@ async def test_calc_metrics_prs_deployments_smoke(client, headers, precomputed_d
     assert values == [[[None, "57352991s"], [None, "60558816s"], [None, "61067133s"], [0, 418]]]
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_calc_metrics_prs_logical(
         client, headers, logical_settings_db, release_match_setting_tag_logical_db):
     body = {
@@ -1015,6 +1063,8 @@ async def test_calc_metrics_prs_logical(
     assert values == [[266, 52, 205, 197]]
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @with_defer
 async def test_calc_metrics_prs_release_ignored(
         client, headers, mdb, pdb, rdb, release_match_setting_tag, pr_miner, prefixer,
@@ -1056,6 +1106,8 @@ async def test_calc_metrics_prs_release_ignored(
     assert result["calculated"][0]["values"][0]["values"] == ["779385s", 65, 61, 21, 102]
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_code_bypassing_prs_smoke(client, headers):
     body = {
         "account": 1,
@@ -1645,6 +1697,8 @@ async def test_developer_metrics_order(client, headers):
     assert [m[0].values for m in result.calculated[0].values] == [[8], [14]]
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_release_metrics_smoke(client, headers, no_jira):
     body = {
         "account": 1,
@@ -1759,6 +1813,8 @@ async def test_release_metrics_participants_groups(client, headers):
     assert models[1].values[0].values[0] == 4
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.parametrize("account, date_to, quantiles, extra_metrics, in_, code",
                          [(3, "2020-02-22", [0, 1], [], "{1}", 404),
                           (2, "2020-02-22", [0, 1], [], "github.com/src-d/go-git", 422),
@@ -1946,6 +2002,8 @@ async def test_release_metrics_participants_many_participants(client, headers):
     assert models[1].values[0].values[0] == 21
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_code_check_metrics_smoke(client, headers):
     body = {
         "account": 1,
@@ -1980,6 +2038,8 @@ async def test_code_check_metrics_smoke(client, headers):
     }
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_code_check_metrics_jira(client, headers):
     body = {
         "account": 1,
@@ -2018,6 +2078,8 @@ async def test_code_check_metrics_jira(client, headers):
     }
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_code_check_metrics_labels(client, headers):
     body = {
         "account": 1,
@@ -2074,6 +2136,8 @@ async def test_code_check_metrics_labels(client, headers):
     }
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_code_check_metrics_split_by_check_runs(client, headers):
     body = {
         "account": 1,
@@ -2139,6 +2203,8 @@ async def test_code_check_metrics_split_by_check_runs(client, headers):
     }
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_code_check_metrics_repogroups(client, headers):
     body = {
         "account": 1,
@@ -2176,6 +2242,8 @@ async def test_code_check_metrics_repogroups(client, headers):
     }
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_code_check_metrics_authorgroups(client, headers):
     body = {
         "account": 1,
@@ -2215,6 +2283,8 @@ async def test_code_check_metrics_authorgroups(client, headers):
     }
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_code_check_metrics_lines(client, headers):
     body = {
         "account": 1,
@@ -2283,6 +2353,8 @@ async def test_code_check_metrics_nasty_input(client, headers, account, repos, m
     assert response.status == code, "Response body is : " + body
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_code_check_metrics_logical_repos(client, headers, logical_settings_db):
     body = {
         "account": 1,
@@ -2317,6 +2389,8 @@ async def test_code_check_metrics_logical_repos(client, headers, logical_setting
     }
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_deployment_metrics_smoke(client, headers, sample_deployments):
     body = {
         "account": 1,

--- a/server/tests/controllers/test_pagination_controller.py
+++ b/server/tests/controllers/test_pagination_controller.py
@@ -9,6 +9,8 @@ from athenian.api.models.state.models import ReleaseSetting
 from athenian.api.models.web import PullRequestPaginationPlan, PullRequestStage
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.filter_pull_requests
 @pytest.mark.parametrize("batch, count",
                          [(100, 8),
@@ -77,6 +79,8 @@ async def test_paginate_prs_nasty_input(client, headers, account, batch, stages,
     assert response.status == code, text
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_paginate_prs_jira(client, headers):
     print("filter", flush=True)
     main_request = {
@@ -123,6 +127,8 @@ async def test_paginate_prs_jira(client, headers):
     assert model.updated == [date(2018, 4, 1), date(2017, 10, 13)]
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_paginate_prs_no_done(client, headers):
     print("filter", flush=True)
     main_request = {
@@ -200,6 +206,8 @@ async def test_paginate_prs_empty(client, headers):
     assert model.updated == [date(2015, 1, 1), date(2015, 1, 1)]
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_paginate_prs_same_day(client, headers, sdb):
     await sdb.execute(insert(ReleaseSetting).values(ReleaseSetting(
         repository="github.com/src-d/go-git",

--- a/server/tests/controllers/test_reposet_controller.py
+++ b/server/tests/controllers/test_reposet_controller.py
@@ -9,6 +9,8 @@ from athenian.api.models.web import RepositorySetCreateRequest, RepositorySetWit
 from athenian.api.response import ResponseError
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_delete_repository_set(client, app, headers, disable_default_user, sdb):
     body = {}
     response = await client.request(

--- a/server/tests/controllers/test_settings_controller.py
+++ b/server/tests/controllers/test_settings_controller.py
@@ -331,6 +331,8 @@ JIRA_PROJECTS = [
 ]
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_get_jira_projects_smoke(client, headers, disabled_dev):
     response = await client.request(
         method="GET", path="/v1/settings/jira/projects/1", headers=headers)
@@ -346,6 +348,8 @@ async def test_get_jira_projects_nasty_input(client, headers, account, code):
     assert response.status == code
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_set_jira_projects_smoke(client, headers, disable_default_user):
     body = {
         "account": 1,
@@ -386,6 +390,8 @@ async def test_set_jira_projects_nasty_input(
     assert response.status == code
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_get_jira_identities_smoke(client, headers, sdb, denys_id_mapping):
     response = await client.request(
         method="GET", path="/v1/settings/jira/identities/1", headers=headers)
@@ -405,6 +411,8 @@ async def test_get_jira_identities_smoke(client, headers, sdb, denys_id_mapping)
     assert has_match
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_get_jira_identities_empty(client, headers):
     response = await client.request(
         method="GET", path="/v1/settings/jira/identities/1", headers=headers)
@@ -425,6 +433,8 @@ async def test_get_jira_identities_nasty_input(client, headers, account, code):
     assert response.status == code
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_set_jira_identities_smoke(client, headers, sdb, denys_id_mapping):
     body = {
         "account": 1,
@@ -451,6 +461,8 @@ async def test_set_jira_identities_smoke(client, headers, sdb, denys_id_mapping)
     assert rows[0][MappedJIRAIdentity.confidence.name] == 1
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_set_jira_identities_reset_cache(client, headers, denys_id_mapping, client_cache):
     async def fetch_contribs():
         return sorted(json.loads(
@@ -492,6 +504,8 @@ async def test_set_jira_identities_reset_cache(client, headers, denys_id_mapping
     assert contribs2 == contribs3
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_set_jira_identities_delete(client, headers, sdb, denys_id_mapping):
     body = {
         "account": 1,
@@ -543,6 +557,8 @@ async def test_set_jira_identities_nasty_input(client, headers, account, github,
     assert response.status == code
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_get_work_type_smoke(client, headers):
     body = {
         "account": 1,
@@ -574,6 +590,8 @@ async def test_get_work_type_nasty_input(client, headers, body, status):
     assert response.status == status, "Response body is : " + body
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_delete_work_type_smoke(client, headers, sdb):
     body = {
         "account": 1,
@@ -610,6 +628,8 @@ async def test_delete_work_type_nasty_input(client, headers, body, status, sdb):
     assert row is not None
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_list_work_types_smoke(client, headers):
     response = await client.request(
         method="GET", path="/v1/settings/work_types/1", headers=headers)
@@ -844,6 +864,8 @@ async def logical_settings_with_labels(sdb):
     ).create_defaults().explode()))
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_list_logical_repositories_smoke(
         client, headers, sdb, logical_settings_with_labels, release_match_setting_tag_logical_db,
         logical_reposet):
@@ -889,6 +911,8 @@ async def test_list_logical_repositories_nasty_input(
     assert response.status == code, "Response body is : " + body
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_delete_logical_repository_smoke(
         client, headers, logical_settings_db, release_match_setting_tag_logical_db, sdb):
     body = {
@@ -940,6 +964,8 @@ async def test_delete_logical_repository_nasty_input(
     assert response.status == code, "Response body is: " + body
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_set_logical_repository_smoke(client, headers, sdb):
     await _test_set_logical_repository(client, headers, sdb, 1)
 
@@ -989,6 +1015,8 @@ async def _test_set_logical_repository(client, headers, sdb, n):
     assert row[ReleaseSetting.match.name] == ReleaseMatch.tag
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_set_logical_repository_replace(
         client, headers, logical_settings_db, release_match_setting_tag_logical_db, sdb):
     await _test_set_logical_repository(client, headers, sdb, 2)

--- a/server/tests/controllers/test_team_controller.py
+++ b/server/tests/controllers/test_team_controller.py
@@ -430,6 +430,8 @@ async def test_update_team_parent_cycle(client, headers, sdb, disable_default_us
     assert "cycle" in body
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_delete_team_smoke(client, headers, sdb, disable_default_user):
     await sdb.execute(insert(Team).values(Team(
         owner_id=1,
@@ -472,6 +474,8 @@ async def test_delete_team_default_user(client, headers, sdb):
     assert response.status == 403, "Response body is : " + body
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.parametrize("owner, id, status", [
     (1, 2, 404),
     (2, 1, 200),

--- a/server/tests/controllers/test_team_controller.py
+++ b/server/tests/controllers/test_team_controller.py
@@ -335,6 +335,8 @@ async def test_resync_teams_regular_user(client, headers, disable_default_user):
     assert response.status == 403, "Response body is : " + body
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_update_team_smoke(client, headers, sdb, disable_default_user):
     await sdb.execute(insert(Team).values(Team(
         owner_id=1, name="Test", members=["github.com/vmarkovtsev"],
@@ -368,6 +370,8 @@ async def test_update_team_default_user(client, headers, sdb):
     assert response.status == 403
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @pytest.mark.parametrize("owner, id, name, members, parent, status", [
     (1, 1, "Engineering", [], None, 400),
     (1, 1, "", ["github.com/se7entyse7en"], None, 400),

--- a/server/tests/test_cache.py
+++ b/server/tests/test_cache.py
@@ -144,6 +144,8 @@ async def test_cached_methods(cache, met_name):
     assert isinstance(met.cache_key("yes", "whatever", cache), bytes)
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 @freeze_time("2022-01-01")
 async def test_expires_header(client, headers, client_cache):
     body = {
@@ -152,6 +154,7 @@ async def test_expires_header(client, headers, client_cache):
     }
     response = await client.request(
         method="POST", path="/v1/filter/labels", headers=headers, json=body)
+    assert response.status == 200
     exp1 = response.headers["expires"]
     assert exp1 == "Sat, 01 Jan 2022 01:00:00 GMT"  # + middle_term_exptime = 1 hour
     time.sleep(1)

--- a/server/tests/test_heavy_load.py
+++ b/server/tests/test_heavy_load.py
@@ -1,8 +1,12 @@
 import asyncio
 
+import pytest
+
 from athenian.api.async_utils import gather
 
 
+# TODO: fix response validation against the schema
+@pytest.mark.app_validate_responses(False)
 async def test_heavy_load(client, headers):
     req_body = {
         "for": [


### PR DESCRIPTION
Add `validate_responses=True` in tests App to validate all generated responses against their declared schemas.
Often we doesn't honour the schema, for that cases app_validate_responses pytest mark has been created.
Those overrides can be gradually fixed and removed.