### PR TITLE
[DEV-4192] teams forbid unsetting parent

### DIFF
--- a/server/athenian/api/controllers/team_controller.py
+++ b/server/athenian/api/controllers/team_controller.py
@@ -139,28 +139,34 @@ async def update_team(request: AthenianWebRequest, id: int,
     body = TeamUpdateRequest.from_dict(body)
     name = _check_name(body.name)
     async with request.sdb.connection() as sdb_conn:
-        account = await sdb_conn.fetch_val(select([Team.owner_id]).where(Team.id == id))
-        if account is None:
-            return ResponseError(NotFoundError("Team %d was not found." % id)).response
-        await get_user_account_status_from_request(request, account)
-        if id == body.parent:
-            raise ResponseError(BadRequestError(detail="Team cannot be a the parent of itself."))
-        meta_ids = await get_metadata_account_ids(account, sdb_conn, request.cache)
-        members = await _resolve_members(body.members, meta_ids, request.mdb)
-        await _check_parent(account, body.parent, sdb_conn)
-        await _check_parent_cycle(id, body.parent, sdb_conn)
-        values = {
-            Team.updated_at.name: datetime.now(timezone.utc),
-            Team.name.name: name,
-            Team.members.name: members,
-            Team.parent_id.name: body.parent,
-        }
-        try:
-            await sdb_conn.execute(update(Team).where(Team.id == id).values(values))
-        except (UniqueViolationError, IntegrityError, OperationalError) as err:
-            return ResponseError(DatabaseConflict(
-                detail="Team '%s' already exists: %s: %s" % (name, type(err).__name__, err)),
-            ).response
+        async with sdb_conn.transaction():
+            team = await sdb_conn.fetch_one(select(Team).where(Team.id == id).with_for_update())
+            if team is None:
+                return ResponseError(NotFoundError(f"Team {id} was not found.")).response
+            account = team[Team.owner_id.name]
+            await get_user_account_status_from_request(request, account)
+            if body.parent is None and team[Team.parent_id.name] is not None:
+                raise ResponseError(BadRequestError(detail="Team parent cannot be unset."))
+            if id == body.parent:
+                raise ResponseError(BadRequestError(
+                    detail="Team cannot be a the parent of itself.",
+                ))
+            meta_ids = await get_metadata_account_ids(account, sdb_conn, request.cache)
+            members = await _resolve_members(body.members, meta_ids, request.mdb)
+            await _check_parent(account, body.parent, sdb_conn)
+            await _check_parent_cycle(id, body.parent, sdb_conn)
+            values = {
+                Team.updated_at.name: datetime.now(timezone.utc),
+                Team.name.name: name,
+                Team.members.name: members,
+                Team.parent_id.name: body.parent,
+            }
+            try:
+                await sdb_conn.execute(update(Team).where(Team.id == id).values(values))
+            except (UniqueViolationError, IntegrityError, OperationalError) as err:
+                return ResponseError(DatabaseConflict(
+                    detail="Team '%s' already exists: %s: %s" % (name, type(err).__name__, err)),
+                ).response
     return web.json_response({})
 
 

--- a/server/athenian/api/controllers/team_controller.py
+++ b/server/athenian/api/controllers/team_controller.py
@@ -161,7 +161,7 @@ async def update_team(request: AthenianWebRequest, id: int,
             return ResponseError(DatabaseConflict(
                 detail="Team '%s' already exists: %s: %s" % (name, type(err).__name__, err)),
             ).response
-    return web.Response()
+    return web.json_response({})
 
 
 def _check_name(name: str) -> str:

--- a/server/athenian/api/controllers/team_controller.py
+++ b/server/athenian/api/controllers/team_controller.py
@@ -149,14 +149,14 @@ async def update_team(request: AthenianWebRequest, id: int,
         members = await _resolve_members(body.members, meta_ids, request.mdb)
         await _check_parent(account, body.parent, sdb_conn)
         await _check_parent_cycle(id, body.parent, sdb_conn)
-        t = Team(
-            owner_id=account,
-            name=name,
-            members=members,
-            parent_id=body.parent,
-        ).create_defaults()
+        values = {
+            Team.updated_at.name: datetime.now(timezone.utc),
+            Team.name.name: name,
+            Team.members.name: members,
+            Team.parent_id.name: body.parent,
+        }
         try:
-            await sdb_conn.execute(update(Team).where(Team.id == id).values(t.explode()))
+            await sdb_conn.execute(update(Team).where(Team.id == id).values(values))
         except (UniqueViolationError, IntegrityError, OperationalError) as err:
             return ResponseError(DatabaseConflict(
                 detail="Team '%s' already exists: %s: %s" % (name, type(err).__name__, err)),

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -307,13 +307,16 @@ async def god(sdb) -> None:
     ).create_defaults().explode(with_primary_keys=True)))
 
 
+DEFAULT_HEADERS = {
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+    "Origin": "http://localhost",
+}
+
+
 @pytest.fixture(scope="function")
 def headers() -> Dict[str, str]:
-    return {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-        "Origin": "http://localhost",
-    }
+    return dict(DEFAULT_HEADERS)
 
 
 @pytest.fixture(scope="session")

--- a/server/tests/controllers/test_team_controller.py
+++ b/server/tests/controllers/test_team_controller.py
@@ -342,8 +342,6 @@ async def test_resync_teams_regular_user(client, headers, disable_default_user):
 
 
 class TestUpdateTeam:
-    # TODO: fix response validation against the schema
-    @pytest.mark.app_validate_responses(False)
     async def test_smoke(self, client, sdb, disable_default_user):
         for model in (
             TeamFactory(id=10, name="Parent"),
@@ -365,8 +363,6 @@ class TestUpdateTeam:
         body = TeamUpdateRequest("Engineering", ["github.com/se7entyse7en"], None).to_dict()
         await self._request(client, 1, body, 403)
 
-    # TODO: fix response validation against the schema
-    @pytest.mark.app_validate_responses(False)
     @pytest.mark.parametrize("owner, id, name, members, parent, status", [
         (1, 1, "Engineering", [], None, 400),
         (1, 1, "", ["github.com/se7entyse7en"], None, 400),


### PR DESCRIPTION
This change is required for Align root team creation, but applicable from now since FE should never change the parent of a team.

Also this avoid `created_at` to be reset when updating the team.

