### PR TITLE
[DEV-4648] Fix xfailing test for branche releases on logical repo

### DIFF
--- a/server/tests/controllers/miners/github/test_release.py
+++ b/server/tests/controllers/miners/github/test_release.py
@@ -378,12 +378,9 @@ async def test_load_releases_events_logical(
     assert list(releases[Release.repository_node_id.name]) == [40550]
 
 
-# TODO: fixed in DEV-4648
-@pytest.mark.xfail
 @with_defer
-async def test_load_releases_branch_logical(
+async def test_load_releases_branch_logical_not_supported(
     branches,
-    default_branches,
     mdb,
     pdb,
     rdb,
@@ -391,35 +388,30 @@ async def test_load_releases_branch_logical(
     prefixer,
     logical_settings,
 ):
-    await models_insert(
-        rdb,
-        ReleaseNotificationFactory(
-            repository_node_id=40550, published_at=dt(2019, 2, 2), commit_hash_prefix="8d20cc5",
-        ),
-    )
+    default_branches = {"src-d/go-git/alpha": "master", "src-d/go-git/beta": "master"}
     release_settings = ReleaseSettings(
         {
             "github.com/src-d/go-git/alpha": _mk_rel_match_settings(events=".*"),
             "github.com/src-d/go-git/beta": _mk_rel_match_settings(branches="{{default}}"),
         },
     )
-    # fails in group_repos_by_release_match
-    releases, _ = await release_loader.load_releases(
-        ["src-d/go-git/alpha", "src-d/go-git/beta"],
-        branches,
-        default_branches,
-        dt(2015, 1, 1),
-        dt(2020, 10, 22),
-        release_settings,
-        logical_settings,
-        prefixer,
-        1,
-        (6366825,),
-        mdb,
-        pdb,
-        rdb,
-        None,
-    )
+    with pytest.raises(AssertionError):
+        await release_loader.load_releases(
+            ["src-d/go-git/alpha", "src-d/go-git/beta"],
+            branches,
+            default_branches,
+            dt(2015, 1, 1),
+            dt(2020, 10, 22),
+            release_settings,
+            logical_settings,
+            prefixer,
+            1,
+            (6366825,),
+            mdb,
+            pdb,
+            rdb,
+            None,
+        )
 
 
 @with_defer


### PR DESCRIPTION
This combination is not supported by design and API already forbids to
set such value.