### PR TITLE
[DEV-4921] gql current metric values support jira filters

### DIFF
--- a/server/athenian/api/align/models.py
+++ b/server/athenian/api/align/models.py
@@ -279,13 +279,16 @@ class MetricValues(Model):
         return self._value
 
 
-class _BaseGoalInputFields(metaclass=Enum):  # noqa: PIE795
-    name = "name"
-    metric = "metric"
+class _GoalMetricFilters(metaclass=Enum):  # noqa: PIE795
     repositories = "repositories"
     jiraProjects = "jiraProjects"
     jiraPriorities = "jiraPriorities"
     jiraIssueTypes = "jiraIssueTypes"
+
+
+class _BaseGoalInputFields(_GoalMetricFilters):
+    name = "name"
+    metric = "metric"
 
 
 class CreateGoalInputFields(_BaseGoalInputFields):
@@ -325,12 +328,11 @@ class TeamGoalChangeFields(metaclass=Enum):
     remove = "remove"
 
 
-class MetricParamsFields(metaclass=Enum):
+class MetricParamsFields(_GoalMetricFilters):
     """Fields definitions for GraphQL MetricParams type."""
 
     teamId = "teamId"
     metrics = "metrics"
-    repositories = "repositories"
     validFrom = "validFrom"
     expiresAt = "expiresAt"
 

--- a/server/athenian/api/align/queries/metrics.py
+++ b/server/athenian/api/align/queries/metrics.py
@@ -329,10 +329,11 @@ async def calculate_team_metrics(
                     [
                         TeamSpecificFilters(
                             team_id=team_id,
+                            participants=_jirafy_team(td.members, jira_map),
                             repositories=td.repositories
                             if td.repositories is not None
                             else all_repos,
-                            participants=_jirafy_team(td.members, jira_map),
+                            jira_filter=td.jira_filter,
                         )
                         for team_id, td in request.teams.items()
                     ],

--- a/server/athenian/api/align/queries/metrics.py
+++ b/server/athenian/api/align/queries/metrics.py
@@ -306,14 +306,15 @@ async def calculate_team_metrics(
                     [
                         TeamSpecificFilters(
                             team_id=team_id,
-                            repositories=td.repositories
-                            if td.repositories is not None
-                            else all_repos,
                             participants={
                                 ReleaseParticipationKind.PR_AUTHOR: td.members,
                                 ReleaseParticipationKind.COMMIT_AUTHOR: td.members,
                                 ReleaseParticipationKind.RELEASER: td.members,
                             },
+                            repositories=td.repositories
+                            if td.repositories is not None
+                            else all_repos,
+                            jira_filter=td.jira_filter,
                         )
                         for team_id, td in request.teams.items()
                     ],

--- a/server/athenian/api/internal/features/entries.py
+++ b/server/athenian/api/internal/features/entries.py
@@ -868,6 +868,9 @@ class MetricEntriesCalculator:
         all_participants = self._merge_release_participants(
             t.participants for request in requests for t in request.teams
         )
+        jira_filters = list(chain.from_iterable(req.all_jira_filters() for req in requests))
+        jira_filter = reduce(operator.or_, jira_filters)
+
         releases, _, _, _ = await mine_releases(
             all_repositories,
             all_participants,
@@ -876,7 +879,7 @@ class MetricEntriesCalculator:
             time_from,
             time_to,
             LabelFilter.empty(),
-            JIRAFilter.empty(),  # should be possible to deduce from requests
+            jira_filter,
             release_settings,
             logical_settings,
             prefixer,

--- a/server/athenian/api/internal/features/entries.py
+++ b/server/athenian/api/internal/features/entries.py
@@ -1267,12 +1267,17 @@ class MetricEntriesCalculator:
         reporters, assignees, commenters = self._merge_jira_participants(
             [t.participants for request in requests for t in request.teams],
         )
+
+        jira_filters = list(chain.from_iterable(req.all_jira_filters() for req in requests))
+        jira_filter = reduce(operator.or_, jira_filters)
+        if not jira_filter:
+            jira_filter = JIRAFilter.from_jira_config(jira_ids)
+
         assert reporters or assignees or commenters
         issues = await fetch_jira_issues(
             time_from,
             time_to,
-            # we can deduce the common superset from requests if possible
-            JIRAFilter.from_jira_config(jira_ids),
+            jira_filter,
             exclude_inactive,
             reporters,
             assignees,

--- a/server/tests/internal/features/test_entries.py
+++ b/server/tests/internal/features/test_entries.py
@@ -328,7 +328,10 @@ class TestBatchCalcPullRequestMetrics:
                 [[dt(2018, 1, 1), dt(2019, 9, 1)]],
                 [
                     TeamSpecificFilters(
-                        1, ["src-d/go-git"], {PRParticipationKind.AUTHOR: {"mcuadros"}},
+                        1,
+                        ["src-d/go-git"],
+                        {PRParticipationKind.AUTHOR: {"mcuadros"}},
+                        JIRAFilter.empty(),
                     ),
                 ],
             ),
@@ -337,7 +340,10 @@ class TestBatchCalcPullRequestMetrics:
                 [[dt(2017, 1, 1), dt(2017, 10, 1)]],
                 [
                     TeamSpecificFilters(
-                        1, ["src-d/go-git"], {PRParticipationKind.AUTHOR: {"mcuadros"}},
+                        1,
+                        ["src-d/go-git"],
+                        {PRParticipationKind.AUTHOR: {"mcuadros"}},
+                        JIRAFilter.empty(),
                     ),
                 ],
             ),
@@ -346,7 +352,10 @@ class TestBatchCalcPullRequestMetrics:
                 [[dt(2017, 8, 10), dt(2017, 8, 12)]],
                 [
                     TeamSpecificFilters(
-                        1, ["src-d/go-git"], {PRParticipationKind.AUTHOR: {"mcuadros"}},
+                        1,
+                        ["src-d/go-git"],
+                        {PRParticipationKind.AUTHOR: {"mcuadros"}},
+                        JIRAFilter.empty(),
                     ),
                 ],
             ),
@@ -404,7 +413,10 @@ class TestBatchCalcPullRequestMetrics:
                 [[dt(2019, 8, 25), dt(2019, 9, 1)]],
                 [
                     TeamSpecificFilters(
-                        1, ["src-d/go-git"], {PRParticipationKind.AUTHOR: {"mcuadros"}},
+                        1,
+                        ["src-d/go-git"],
+                        {PRParticipationKind.AUTHOR: {"mcuadros"}},
+                        JIRAFilter.empty(),
                     ),
                 ],
             ),
@@ -507,7 +519,10 @@ class TestBatchCalcReleaseMetrics:
                 time_intervals=[[dt(2018, 6, 12), dt(2020, 11, 11)]],
                 teams=[
                     TeamSpecificFilters(
-                        1, ["src-d/go-git"], {ReleaseParticipationKind.COMMIT_AUTHOR: [39789]},
+                        1,
+                        ["src-d/go-git"],
+                        {ReleaseParticipationKind.COMMIT_AUTHOR: [39789]},
+                        JIRAFilter.empty(),
                     ),
                 ],
             ),
@@ -516,7 +531,10 @@ class TestBatchCalcReleaseMetrics:
                 time_intervals=[[dt(2018, 1, 1), dt(2018, 6, 1)]],
                 teams=[
                     TeamSpecificFilters(
-                        1, ["src-d/go-git"], {ReleaseParticipationKind.COMMIT_AUTHOR: [39789]},
+                        1,
+                        ["src-d/go-git"],
+                        {ReleaseParticipationKind.COMMIT_AUTHOR: [39789]},
+                        JIRAFilter.empty(),
                     ),
                 ],
             ),
@@ -574,7 +592,10 @@ class TestBatchCalcReleaseMetrics:
                 time_intervals=[[dt(2019, 1, 12), dt(2019, 3, 11)]],
                 teams=[
                     TeamSpecificFilters(
-                        1, ["src-d/go-git"], {ReleaseParticipationKind.COMMIT_AUTHOR: [39789]},
+                        1,
+                        ["src-d/go-git"],
+                        {ReleaseParticipationKind.COMMIT_AUTHOR: [39789]},
+                        JIRAFilter.empty(),
                     ),
                 ],
             ),
@@ -683,6 +704,7 @@ class TestBatchCalcJIRAMetrics(BaseCalcJIRAMetricsTest):
                         1,
                         ["src-d/go-git"],
                         {JIRAParticipationKind.REPORTER: ["vadim markovtsev"]},
+                        JIRAFilter.empty(),
                     ),
                 ],
             ),
@@ -694,6 +716,7 @@ class TestBatchCalcJIRAMetrics(BaseCalcJIRAMetricsTest):
                         1,
                         ["src-d/go-git"],
                         {JIRAParticipationKind.REPORTER: ["vadim markovtsev"]},
+                        JIRAFilter.empty(),
                     ),
                 ],
             ),
@@ -752,6 +775,7 @@ class TestBatchCalcJIRAMetrics(BaseCalcJIRAMetricsTest):
                         1,
                         ["src-d/go-git"],
                         {JIRAParticipationKind.REPORTER: ["vadim markovtsev"]},
+                        JIRAFilter.empty(),
                     ),
                 ],
             ),


### PR DESCRIPTION
- support  jira filters in `MetricEntriesCalculator.batch_calc*` methods
- support jira filters in `metricCurrentValues` query (where grouping is not needed) 

Related: DEV-4920