### PR TITLE
[DEV-5074] Do not report validation error to sentry during tests

### DIFF
--- a/server/athenian/api/__main__.py
+++ b/server/athenian/api/__main__.py
@@ -23,7 +23,6 @@ import aiohttp.web
 from aiohttp.web_runner import GracefulExit
 import aiomcache
 import aiomonitor
-from especifico.decorators import validation
 from flogging import flogging
 import jinja2
 import morcilla
@@ -217,7 +216,6 @@ def setup_context(log: logging.Logger) -> None:
     numpy.set_printoptions(threshold=10, edgeitems=1)
     if (level := log.getEffectiveLevel()) >= logging.INFO:
         morcilla.core.logger.setLevel(level + 10)
-    validation.logger.error = validation.logger.warning
 
     _init_sentry(log, app_env)
 

--- a/server/athenian/api/application.py
+++ b/server/athenian/api/application.py
@@ -30,6 +30,7 @@ import aiomcache
 import ariadne
 from asyncpg import InterfaceError, OperatorInterventionError, PostgresConnectionError
 from especifico.apis import aiohttp_api
+from especifico.decorators import validation
 from especifico.exceptions import EspecificoException
 import especifico.lifecycle
 import especifico.security
@@ -78,6 +79,9 @@ from athenian.precomputer.db import dereference_schemas as dereference_precomput
 flogging.trailing_dot_exceptions.update(
     ("asyncio", "especifico.api.security", "especifico.apis.aiohttp_api"),
 )
+
+# demote especifico validation errors so that they are not sent to Sentry
+validation.logger.error = validation.logger.warning
 
 
 class AthenianOperation(especifico.spec.OpenAPIOperation):


### PR DESCRIPTION
These validation errors were already `warning`, so not reported to Sentry`, when running production code.