### PR TITLE
[DEV-5107] web model io fix multibyte unicodestring

### DIFF
--- a/server/athenian/api/controllers/jira_controller.py
+++ b/server/athenian/api/controllers/jira_controller.py
@@ -571,7 +571,6 @@ async def _epic_flow(
         release_settings,
         logical_settings,
     ),
-    version=2,
 )
 async def _issue_flow(
     return_: set[str],


### PR DESCRIPTION
Fix model string handling in web_model_io when python unicode representation has more than one byte per code point