### PR TITLE
[DEV-5347] Extract PRFactsCalculator from MetricEntriesCalculator

### DIFF
--- a/server/athenian/api/controllers/events_controller.py
+++ b/server/athenian/api/controllers/events_controller.py
@@ -34,7 +34,7 @@ from athenian.api.balancing import weight
 from athenian.api.db import Connection, Database, dialect_specific_insert
 from athenian.api.defer import defer, launch_defer_from_request, wait_deferred
 from athenian.api.internal.account import get_installation_url_prefix, get_metadata_account_ids
-from athenian.api.internal.features.entries import MetricEntriesCalculator
+from athenian.api.internal.features.entries import PRFactsCalculator
 from athenian.api.internal.miners.access_classes import access_classes
 from athenian.api.internal.miners.filters import JIRAFilter, LabelFilter
 from athenian.api.internal.miners.github.bots import bots
@@ -421,9 +421,7 @@ async def _drop_precomputed_event_releases(
         with_extended_pr_details=False,
     )
     await gather(wait_deferred(), bots_task)
-    await MetricEntriesCalculator(
-        account, meta_ids, 0, mdb, pdb, rdb, None,
-    ).calc_pull_request_facts_github(
+    await PRFactsCalculator(account, meta_ids, mdb, pdb, rdb, cache=None)(
         time_from,
         time_to,
         set(repos),

--- a/server/athenian/api/precompute/accounts.py
+++ b/server/athenian/api/precompute/accounts.py
@@ -22,7 +22,7 @@ from athenian.api.db import Database, dialect_specific_insert
 from athenian.api.defer import defer, wait_deferred
 from athenian.api.internal.account import copy_teams_as_needed, get_multiple_metadata_account_ids
 from athenian.api.internal.account_feature import is_feature_enabled
-from athenian.api.internal.features.entries import MetricEntriesCalculator
+from athenian.api.internal.features.entries import PRFactsCalculator
 from athenian.api.internal.jira import disable_empty_projects, match_jira_identities
 from athenian.api.internal.miners.filters import JIRAFilter, LabelFilter
 from athenian.api.internal.miners.github.bots import bots as fetch_bots
@@ -321,15 +321,15 @@ async def precompute_reposet(
                     repos, branches, reposet.owner_id, meta_ids, mdb, pdb, None,
                 )
             log.info("Extracting PR facts")
-            facts = await MetricEntriesCalculator(
+            pr_facts_calc = PRFactsCalculator(
                 reposet.owner_id,
                 meta_ids,
-                0,
                 mdb,
                 pdb,
                 rdb,
-                None,  # yes, disable the cache
-            ).calc_pull_request_facts_github(
+                cache=None,  # yes, disable the cache
+            )
+            facts = await pr_facts_calc(
                 time_from,
                 time_to,
                 repos,

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -22,7 +22,7 @@ import sentry_sdk
 import sqlalchemy as sa
 
 from athenian.api.async_utils import read_sql_query
-from athenian.api.internal.features.entries import MetricEntriesCalculator
+from athenian.api.internal.features.entries import MetricEntriesCalculator, PRFactsCalculator
 from tests.testutils.factory.miners import PullRequestFactsFactory
 
 try:
@@ -985,6 +985,21 @@ async def metrics_calculator_factory(mdb, pdb, rdb, cache):
             c = None
 
         return MetricEntriesCalculator(account_id, meta_ids, 28, mdb, pdb, rdb, c)
+
+    return build
+
+
+@pytest.fixture(scope="function")
+async def pr_facts_calculator_factory(mdb, pdb, rdb, cache):
+    def build(account_id, meta_ids, with_cache=False, cache_only=False) -> PRFactsCalculator:
+        if cache_only:
+            return PRFactsCalculator(account_id, meta_ids, None, None, None, cache=cache)
+        if with_cache:
+            c = cache
+        else:
+            c = None
+
+        return PRFactsCalculator(account_id, meta_ids, mdb, pdb, rdb, cache=c)
 
     return build
 

--- a/server/tests/controllers/features/github/test_pull_request_filter.py
+++ b/server/tests/controllers/features/github/test_pull_request_filter.py
@@ -767,7 +767,7 @@ async def test_pr_list_miner_filter_labels_cache_exclude(
 
 @with_defer
 async def test_pr_list_miner_filter_labels_pdb(
-    metrics_calculator_factory,
+    pr_facts_calculator_factory,
     mdb,
     pdb,
     rdb,
@@ -775,10 +775,10 @@ async def test_pr_list_miner_filter_labels_pdb(
     prefixer,
     bots,
 ):
-    metrics_calculator_no_cache = metrics_calculator_factory(1, (6366825,))
+    pr_facts_calculator_no_cache = pr_facts_calculator_factory(1, (6366825,))
     time_from = datetime(2018, 9, 1, tzinfo=timezone.utc)
     time_to = datetime(2018, 11, 19, tzinfo=timezone.utc)
-    await metrics_calculator_no_cache.calc_pull_request_facts_github(
+    await pr_facts_calculator_no_cache(
         time_from,
         time_to,
         {"src-d/go-git"},
@@ -855,7 +855,7 @@ async def test_pr_list_miner_filter_labels_pdb(
 @pytest.mark.parametrize("with_precomputed", [True, False])
 @with_defer
 async def test_pr_list_miner_deployments_production(
-    metrics_calculator_factory,
+    pr_facts_calculator_factory,
     mdb,
     pdb,
     rdb,
@@ -869,8 +869,8 @@ async def test_pr_list_miner_deployments_production(
     time_from = datetime(2018, 9, 1, tzinfo=timezone.utc)
     time_to = datetime(2019, 12, 19, tzinfo=timezone.utc)
     if with_precomputed:
-        metrics_calculator_no_cache = metrics_calculator_factory(1, (6366825,))
-        await metrics_calculator_no_cache.calc_pull_request_facts_github(
+        pr_facts_calculator_no_cache = pr_facts_calculator_factory(1, (6366825,))
+        await pr_facts_calculator_no_cache(
             time_from,
             time_to,
             {"src-d/go-git"},
@@ -1143,7 +1143,7 @@ async def test_pr_list_miner_logical(
 
 @with_defer
 async def test_fetch_pull_requests_smoke(
-    metrics_calculator_factory,
+    pr_facts_calculator_factory,
     mdb,
     pdb,
     rdb,
@@ -1152,10 +1152,10 @@ async def test_fetch_pull_requests_smoke(
     bots,
     cache,
 ):
-    metrics_calculator_no_cache = metrics_calculator_factory(1, (6366825,))
+    pr_facts_calculator_no_cache = pr_facts_calculator_factory(1, (6366825,))
     time_from = datetime(2018, 9, 1, tzinfo=timezone.utc)
     time_to = datetime(2018, 11, 19, tzinfo=timezone.utc)
-    await metrics_calculator_no_cache.calc_pull_request_facts_github(
+    await pr_facts_calculator_no_cache(
         time_from,
         time_to,
         {"src-d/go-git"},

--- a/server/tests/controllers/features/github/test_pull_request_metrics.py
+++ b/server/tests/controllers/features/github/test_pull_request_metrics.py
@@ -464,7 +464,7 @@ async def test_calc_pull_request_metrics_line_github_cache_reset(
         factory = metrics_calculator_factory_memcached
     else:
         factory = metrics_calculator_factory
-    metrics_calculator = factory(1, (6366825,), with_cache=True)
+    pr_facts_calculator = factory(1, (6366825,), with_cache=True)
     date_from = datetime(year=2017, month=1, day=1, tzinfo=timezone.utc)
     date_to = datetime(year=2019, month=10, day=1, tzinfo=timezone.utc)
     args = (
@@ -486,11 +486,11 @@ async def test_calc_pull_request_metrics_line_github_cache_reset(
         default_branches,
         False,
     )
-    metrics1 = (await metrics_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
+    metrics1 = (await pr_facts_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][
         0
-    ][0]
+    ][0][0]
     await wait_deferred()
-    assert await metrics_calculator.calc_pull_request_metrics_line_github.reset_cache(*args)
+    assert await pr_facts_calculator.calc_pull_request_metrics_line_github.reset_cache(*args)
     if with_mine_cache_wipe:
         assert await pr_miner._mine.reset_cache(
             None,
@@ -518,9 +518,9 @@ async def test_calc_pull_request_metrics_line_github_cache_reset(
             rdb,
             cache,
         )
-    metrics2 = (await metrics_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
+    metrics2 = (await pr_facts_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][
         0
-    ][0]
+    ][0][0]
     assert metrics1.exists and metrics2.exists
     assert metrics1.value == metrics2.value
     assert metrics1.confidence_score() == metrics2.confidence_score()
@@ -536,7 +536,7 @@ async def test_calc_pull_request_metrics_line_github_cache_lines(
     branches,
     default_branches,
 ):
-    metrics_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
+    pr_facts_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
     date_from = datetime(year=2017, month=1, day=1, tzinfo=timezone.utc)
     date_to = datetime(year=2019, month=10, day=1, tzinfo=timezone.utc)
     args = [
@@ -558,14 +558,14 @@ async def test_calc_pull_request_metrics_line_github_cache_lines(
         default_branches,
         False,
     ]
-    metrics1 = (await metrics_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
+    metrics1 = (await pr_facts_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][
         0
-    ][0]
+    ][0][0]
     await wait_deferred()
     args[3] = []
-    metrics2 = (await metrics_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
+    metrics2 = (await pr_facts_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][
         0
-    ][0]
+    ][0][0]
     assert metrics1 != metrics2
 
 
@@ -582,7 +582,7 @@ async def test_calc_pull_request_metrics_line_github_changed_releases(
     branches,
     default_branches,
 ):
-    metrics_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
+    pr_facts_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
     date_from = datetime(year=2017, month=1, day=1, tzinfo=timezone.utc)
     date_to = datetime(year=2017, month=10, day=1, tzinfo=timezone.utc)
     args = [
@@ -604,9 +604,9 @@ async def test_calc_pull_request_metrics_line_github_changed_releases(
         default_branches,
         False,
     ]
-    metrics1 = (await metrics_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
+    metrics1 = (await pr_facts_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][
         0
-    ][0]
+    ][0][0]
     await wait_deferred()
     release_match_setting_tag = ReleaseSettings(
         {
@@ -616,9 +616,9 @@ async def test_calc_pull_request_metrics_line_github_changed_releases(
         },
     )
     args[-6] = release_match_setting_tag
-    metrics2 = (await metrics_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
+    metrics2 = (await pr_facts_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][
         0
-    ][0]
+    ][0][0]
     assert metrics1 != metrics2
 
 
@@ -719,7 +719,7 @@ async def test_calc_pull_request_metrics_line_github_exclude_inactive(
     branches,
     default_branches,
 ):
-    metrics_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
+    pr_facts_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
     date_from = datetime(year=2017, month=1, day=1, tzinfo=timezone.utc)
     date_to = datetime(year=2017, month=1, day=12, tzinfo=timezone.utc)
     args = [
@@ -741,13 +741,13 @@ async def test_calc_pull_request_metrics_line_github_exclude_inactive(
         default_branches,
         False,
     ]
-    metrics = (await metrics_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
+    metrics = (await pr_facts_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
         0
     ][0]
     await wait_deferred()
     assert metrics.value == 7
     args[9] = True
-    metrics = (await metrics_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
+    metrics = (await pr_facts_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
         0
     ][0]
     await wait_deferred()
@@ -757,18 +757,18 @@ async def test_calc_pull_request_metrics_line_github_exclude_inactive(
     args[0] = [PullRequestMetricID.PR_RELEASE_COUNT]
     args[1] = [[date_from, date_to]]
     args[9] = False
-    metrics = (await metrics_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
+    metrics = (await pr_facts_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
         0
     ][0]
     await wait_deferred()
     assert metrics.value == 71
-    metrics = (await metrics_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
+    metrics = (await pr_facts_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
         0
     ][0]
     await wait_deferred()
     assert metrics.value == 71
     args[9] = True
-    metrics = (await metrics_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
+    metrics = (await pr_facts_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
         0
     ][0]
     assert metrics.value == 71
@@ -783,7 +783,7 @@ async def test_calc_pull_request_metrics_line_github_quantiles(
     branches,
     default_branches,
 ):
-    metrics_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
+    pr_facts_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
     date_from = datetime(year=2017, month=1, day=1, tzinfo=timezone.utc)
     date_to = datetime(year=2017, month=1, day=12, tzinfo=timezone.utc)
     args = [
@@ -805,13 +805,13 @@ async def test_calc_pull_request_metrics_line_github_quantiles(
         default_branches,
         False,
     ]
-    metrics = (await metrics_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
+    metrics = (await pr_facts_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
         0
     ][0]
     await wait_deferred()
     assert metrics.value == 25
     args[2] = [0, 1]
-    metrics = (await metrics_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
+    metrics = (await pr_facts_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
         0
     ][0]
     await wait_deferred()
@@ -833,7 +833,7 @@ async def test_calc_pull_request_metrics_line_github_tag_after_branch(
     branches,
     default_branches,
 ):
-    metrics_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
+    pr_facts_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
     date_from = datetime(year=2017, month=1, day=1, tzinfo=timezone.utc)
     date_to = datetime(year=2018, month=1, day=12, tzinfo=timezone.utc)
     args = [
@@ -855,13 +855,13 @@ async def test_calc_pull_request_metrics_line_github_tag_after_branch(
         default_branches,
         False,
     ]
-    metrics = (await metrics_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
+    metrics = (await pr_facts_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
         0
     ][0]
     await wait_deferred()
     assert metrics.value == timedelta(seconds=392)
     args[-6] = release_match_setting_tag_or_branch
-    metrics = (await metrics_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
+    metrics = (await pr_facts_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
         0
     ][0]
     assert metrics.value == timedelta(days=40, seconds=72739)
@@ -881,7 +881,7 @@ async def test_calc_pull_request_metrics_line_github_deployment_hazard(
     branches,
     default_branches,
 ):
-    metrics_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
+    pr_facts_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
     date_from = datetime(year=2019, month=1, day=1, tzinfo=timezone.utc)
     date_to = datetime(year=2020, month=1, day=12, tzinfo=timezone.utc)
     args = [
@@ -903,7 +903,7 @@ async def test_calc_pull_request_metrics_line_github_deployment_hazard(
         default_branches,
         False,
     ]
-    metrics = (await metrics_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
+    metrics = (await pr_facts_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
         0
     ][0]
     await wait_deferred()
@@ -923,7 +923,7 @@ async def test_calc_pull_request_metrics_line_jira_map(
     branches,
     default_branches,
 ):
-    metrics_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
+    pr_facts_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
     date_from = datetime(year=2017, month=1, day=1, tzinfo=timezone.utc)
     date_to = datetime(year=2018, month=1, day=12, tzinfo=timezone.utc)
     metrics = [
@@ -950,7 +950,7 @@ async def test_calc_pull_request_metrics_line_jira_map(
         default_branches,
         False,
     ]
-    metrics = (await metrics_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
+    metrics = (await pr_facts_calculator.calc_pull_request_metrics_line_github(*args))[0][0][0][0][
         0
     ]
     await wait_deferred()
@@ -972,7 +972,7 @@ async def test_calc_pull_request_metrics_deep_filters(
     branches,
     default_branches,
 ):
-    metrics_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
+    pr_facts_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
     release_settings = release_match_setting_tag_or_branch.copy()
     for r in ("gitbase", "hercules"):
         release_settings.native["src-d/" + r] = release_settings.prefixed[
@@ -1010,7 +1010,7 @@ async def test_calc_pull_request_metrics_deep_filters(
     # 4. time series primary: 2 groups
     # 5. time series secondary: 1 and 2 groups
     # 6. metrics: 3 groups
-    metrics = await metrics_calculator.calc_pull_request_metrics_line_github(*args)
+    metrics = await pr_facts_calculator.calc_pull_request_metrics_line_github(*args)
     metric = MetricInt.from_fields
     ground_truth = np.array(
         [
@@ -1292,8 +1292,8 @@ def test_pull_request_metric_calculator_ensemble_empty(pr_samples):
 
 
 @with_defer
-async def test_calc_pull_request_facts_github_open_precomputed(
-    metrics_calculator_factory,
+async def test_pr_facts_calculator_open_precomputed(
+    pr_facts_calculator_factory,
     mdb,
     pdb,
     rdb,
@@ -1301,7 +1301,7 @@ async def test_calc_pull_request_facts_github_open_precomputed(
     prefixer,
     bots,
 ):
-    metrics_calculator_no_cache = metrics_calculator_factory(1, (6366825,))
+    pr_facts_calculator_no_cache = pr_facts_calculator_factory(1, (6366825,))
     time_from = datetime(year=2018, month=1, day=1, tzinfo=timezone.utc)
     time_to = datetime(year=2020, month=4, day=1, tzinfo=timezone.utc)
     args = (
@@ -1319,19 +1319,19 @@ async def test_calc_pull_request_facts_github_open_precomputed(
         False,
         JIRAEntityToFetch.NOTHING,
     )
-    facts1 = await metrics_calculator_no_cache.calc_pull_request_facts_github(*args)
+    facts1 = await pr_facts_calculator_no_cache(*args)
     facts1.sort_values(PullRequestFacts.f.created, inplace=True, ignore_index=True)
     await wait_deferred()
     open_facts = await pdb.fetch_all(select([GitHubOpenPullRequestFacts]))
     assert len(open_facts) == 21
-    facts2 = await metrics_calculator_no_cache.calc_pull_request_facts_github(*args)
+    facts2 = await pr_facts_calculator_no_cache(*args)
     facts2.sort_values(PullRequestFacts.f.created, inplace=True, ignore_index=True)
     assert_frame_equal(facts1, facts2)
 
 
 @with_defer
-async def test_calc_pull_request_facts_github_unreleased_precomputed(
-    metrics_calculator_factory,
+async def test_pr_facts_calculator_unreleased_precomputed(
+    pr_facts_calculator_factory,
     mdb,
     pdb,
     rdb,
@@ -1339,7 +1339,7 @@ async def test_calc_pull_request_facts_github_unreleased_precomputed(
     prefixer,
     bots,
 ):
-    metrics_calculator_no_cache = metrics_calculator_factory(1, (6366825,))
+    pr_facts_calculator_no_cache = pr_facts_calculator_factory(1, (6366825,))
     time_from = datetime(year=2019, month=10, day=30, tzinfo=timezone.utc)
     time_to = datetime(year=2019, month=11, day=2, tzinfo=timezone.utc)
     args = (
@@ -1357,7 +1357,7 @@ async def test_calc_pull_request_facts_github_unreleased_precomputed(
         False,
         JIRAEntityToFetch.NOTHING,
     )
-    facts1 = await metrics_calculator_no_cache.calc_pull_request_facts_github(*args)
+    facts1 = await pr_facts_calculator_no_cache(*args)
     facts1.sort_values(PullRequestFacts.f.created, inplace=True, ignore_index=True)
     await wait_deferred()
     unreleased_facts = await pdb.fetch_all(select([GitHubMergedPullRequestFacts]))
@@ -1366,14 +1366,14 @@ async def test_calc_pull_request_facts_github_unreleased_precomputed(
         assert row[GitHubMergedPullRequestFacts.data.name] is not None, row[
             GitHubMergedPullRequestFacts.pr_node_id.name
         ]
-    facts2 = await metrics_calculator_no_cache.calc_pull_request_facts_github(*args)
+    facts2 = await pr_facts_calculator_no_cache(*args)
     facts2.sort_values(PullRequestFacts.f.created, inplace=True, ignore_index=True)
     assert_frame_equal(facts1, facts2)
 
 
 @with_defer
-async def test_calc_pull_request_facts_github_jira(
-    metrics_calculator_factory,
+async def test_pr_facts_calculator_jira(
+    pr_facts_calculator_factory,
     mdb,
     pdb,
     rdb,
@@ -1382,8 +1382,8 @@ async def test_calc_pull_request_facts_github_jira(
     bots,
     cache,
 ):
-    metrics_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
-    metrics_calculator_cache_only = metrics_calculator_factory(1, (6366825,), cache_only=True)
+    pr_facts_calculator = pr_facts_calculator_factory(1, (6366825,), with_cache=True)
+    pr_facts_calculator_cache_only = pr_facts_calculator_factory(1, (6366825,), cache_only=True)
     time_from = datetime(year=2018, month=1, day=1, tzinfo=timezone.utc)
     time_to = datetime(year=2020, month=4, day=1, tzinfo=timezone.utc)
     args = [
@@ -1401,7 +1401,7 @@ async def test_calc_pull_request_facts_github_jira(
         False,
         JIRAEntityToFetch.NOTHING,
     ]
-    facts = await metrics_calculator.calc_pull_request_facts_github(*args)
+    facts = await pr_facts_calculator(*args)
     await wait_deferred()
     assert facts[PullRequestFacts.f.released].notnull().sum() == 235
     args[5] = JIRAFilter(
@@ -1414,22 +1414,22 @@ async def test_calc_pull_request_facts_github_jira(
         False,
         0,
     )
-    facts = await metrics_calculator.calc_pull_request_facts_github(*args)
+    facts = await pr_facts_calculator(*args)
     assert facts[PullRequestFacts.f.released].notnull().sum() == 16
 
     args[5] = JIRAFilter.empty()
     args[-1] = JIRAEntityToFetch.ISSUES
-    facts = await metrics_calculator.calc_pull_request_facts_github(*args)
+    facts = await pr_facts_calculator(*args)
 
     assert facts.jira_ids.astype(bool).sum() == 60
     await wait_deferred()
-    facts = await metrics_calculator_cache_only.calc_pull_request_facts_github(*args)
+    facts = await pr_facts_calculator_cache_only(*args)
     assert facts.jira_ids.astype(bool).sum() == 60
 
 
 @with_defer
-async def test_calc_pull_request_facts_github_jira_everything(
-    metrics_calculator_factory,
+async def test_pr_facts_calculator_jira_everything(
+    pr_facts_calculator_factory,
     mdb,
     pdb,
     rdb,
@@ -1438,8 +1438,7 @@ async def test_calc_pull_request_facts_github_jira_everything(
     bots,
     cache,
 ):
-    metrics_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
-    # metrics_calculator_cache_only = metrics_calculator_factory(1, (6366825,), cache_only=True)
+    pr_facts_calculator = pr_facts_calculator_factory(1, (6366825,), with_cache=True)
     time_from = datetime(year=2018, month=1, day=1, tzinfo=timezone.utc)
     time_to = datetime(year=2020, month=4, day=1, tzinfo=timezone.utc)
     args = [
@@ -1457,7 +1456,7 @@ async def test_calc_pull_request_facts_github_jira_everything(
         False,
         JIRAEntityToFetch.EVERYTHING(),
     ]
-    facts = await metrics_calculator.calc_pull_request_facts_github(*args)
+    facts = await pr_facts_calculator(*args)
     pr_fact = facts[facts.node_id == 163209]
     assert facts.jira_ids.astype(bool).sum() == 60
     assert_array_equal(pr_fact.jira_ids.values[0], np.array(["DEV-678"]))
@@ -1467,8 +1466,8 @@ async def test_calc_pull_request_facts_github_jira_everything(
 
 
 @with_defer
-async def test_calc_pull_request_facts_github_event_releases(
-    metrics_calculator_factory,
+async def test_pr_facts_calculator_event_releases(
+    pr_facts_calculator_factory,
     mdb,
     pdb,
     rdb,
@@ -1492,7 +1491,7 @@ async def test_calc_pull_request_facts_github_event_releases(
             .explode(with_primary_keys=True),
         ),
     )
-    metrics_calculator = metrics_calculator_factory(1, (6366825,))
+    pr_facts_calculator = pr_facts_calculator_factory(1, (6366825,))
     time_from = datetime(year=2018, month=1, day=1, tzinfo=timezone.utc)
     time_to = datetime(year=2020, month=4, day=1, tzinfo=timezone.utc)
     args = [
@@ -1510,16 +1509,16 @@ async def test_calc_pull_request_facts_github_event_releases(
         False,
         JIRAEntityToFetch.NOTHING,
     ]
-    facts = await metrics_calculator.calc_pull_request_facts_github(*args)
+    facts = await pr_facts_calculator(*args)
     await wait_deferred()
     assert facts[PullRequestFacts.f.released].notnull().sum() == 381
-    facts = await metrics_calculator.calc_pull_request_facts_github(*args)
+    facts = await pr_facts_calculator(*args)
     assert facts[PullRequestFacts.f.released].notnull().sum() == 381
 
 
 @with_defer
 async def test_calc_pull_request_facts_empty(
-    metrics_calculator_factory,
+    pr_facts_calculator_factory,
     mdb,
     pdb,
     rdb,
@@ -1528,7 +1527,7 @@ async def test_calc_pull_request_facts_empty(
     bots,
     cache,
 ):
-    metrics_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
+    pr_facts_calculator = pr_facts_calculator_factory(1, (6366825,), with_cache=True)
     time_from = datetime(year=2022, month=1, day=1, tzinfo=timezone.utc)
     time_to = datetime(year=2023, month=4, day=1, tzinfo=timezone.utc)
     args = [
@@ -1546,7 +1545,7 @@ async def test_calc_pull_request_facts_empty(
         False,
         JIRAEntityToFetch.NOTHING,
     ]
-    facts = await metrics_calculator.calc_pull_request_facts_github(*args)
+    facts = await pr_facts_calculator(*args)
     assert facts.empty
     assert len(facts.columns) == len(PullRequestFacts.f)
     assert PullRequestFacts.f.done in facts.columns
@@ -1632,11 +1631,11 @@ def test_counter_quantiles(pr_samples):
 @with_defer
 async def real_pr_samples(
     release_match_setting_tag,
-    metrics_calculator_factory,
+    pr_facts_calculator_factory,
     prefixer,
     bots,
 ) -> Tuple[datetime, datetime, pd.DataFrame]:
-    metrics_calculator_no_cache = metrics_calculator_factory(1, (6366825,))
+    pr_facts_calculator_no_cache = pr_facts_calculator_factory(1, (6366825,))
     time_from = datetime(year=2015, month=1, day=1, tzinfo=timezone.utc)
     time_to = datetime(year=2020, month=4, day=1, tzinfo=timezone.utc)
     args = (
@@ -1654,7 +1653,7 @@ async def real_pr_samples(
         False,
         JIRAEntityToFetch.NOTHING,
     )
-    samples = await metrics_calculator_no_cache.calc_pull_request_facts_github(*args)
+    samples = await pr_facts_calculator_no_cache(*args)
     return time_from, time_to, samples
 
 
@@ -1704,7 +1703,7 @@ async def test_pull_request_count_logical_alpha_beta(
         None,
     )
     await wait_deferred()
-    metrics_calculator = metrics_calculator_factory(1, (6366825,))
+    pr_facts_calculator = metrics_calculator_factory(1, (6366825,))
     time_from = datetime(year=2015, month=1, day=1, tzinfo=timezone.utc)
     time_to = datetime(year=2020, month=4, day=1, tzinfo=timezone.utc)
     metrics = [
@@ -1735,7 +1734,7 @@ async def test_pull_request_count_logical_alpha_beta(
             default_branches,
             False,
         ]
-        values = await metrics_calculator.calc_pull_request_metrics_line_github(*args)
+        values = await pr_facts_calculator.calc_pull_request_metrics_line_github(*args)
         await wait_deferred()
         assert values.shape == (1, 2, 1, 1)
 
@@ -1766,7 +1765,7 @@ async def test_pull_request_count_logical_root(
     branches,
     default_branches,
 ):
-    metrics_calculator = metrics_calculator_factory(1, (6366825,))
+    pr_facts_calculator = metrics_calculator_factory(1, (6366825,))
     time_from = datetime(year=2015, month=1, day=1, tzinfo=timezone.utc)
     time_to = datetime(year=2020, month=4, day=1, tzinfo=timezone.utc)
     metrics = [
@@ -1798,7 +1797,7 @@ async def test_pull_request_count_logical_root(
             False,
         ]
         args[5].append(["src-d/go-git"])
-        values = await metrics_calculator.calc_pull_request_metrics_line_github(*args)
+        values = await pr_facts_calculator.calc_pull_request_metrics_line_github(*args)
         await wait_deferred()
         assert values.shape == (1, 3, 1, 1)
         assert values[0, 2, 0, 0][0][0].value == 304
@@ -1807,7 +1806,7 @@ async def test_pull_request_count_logical_root(
         assert values[0, 2, 0, 0][0][3].value == 283
         assert values[0, 2, 0, 0][0][4].value == 230
         args[5] = [["src-d/go-git"]]
-        values = await metrics_calculator.calc_pull_request_metrics_line_github(*args)
+        values = await pr_facts_calculator.calc_pull_request_metrics_line_github(*args)
         await wait_deferred()
         assert values.shape == (1, 1, 1, 1)
         assert values[0, 0, 0, 0][0][0].value == 554

--- a/server/tests/controllers/features/github/test_unfresh.py
+++ b/server/tests/controllers/features/github/test_unfresh.py
@@ -20,7 +20,7 @@ from athenian.api.models.precomputed.models import (
 
 @with_defer
 async def test_fetch_pull_request_facts_unfresh_smoke(
-    metrics_calculator_factory,
+    pr_facts_calculator_factory,
     release_match_setting_tag,
     mdb,
     pdb,
@@ -29,10 +29,10 @@ async def test_fetch_pull_request_facts_unfresh_smoke(
     bots,
     precomputed_deployments,
 ):
-    metrics_calculator_no_cache = metrics_calculator_factory(1, (6366825,))
+    pr_facts_calculator_no_cache = pr_facts_calculator_factory(1, (6366825,))
     time_from = datetime(2017, 9, 1, tzinfo=timezone.utc)
     time_to = datetime(2018, 11, 19, tzinfo=timezone.utc)
-    facts_fresh = await metrics_calculator_no_cache.calc_pull_request_facts_github(
+    facts_fresh = await pr_facts_calculator_no_cache(
         time_from,
         time_to,
         {"src-d/go-git"},
@@ -60,7 +60,7 @@ async def test_fetch_pull_request_facts_unfresh_smoke(
     orig_threshold = entries.unfresh_prs_threshold
     entries.unfresh_prs_threshold = 1
     try:
-        facts_unfresh = await metrics_calculator_no_cache.calc_pull_request_facts_github(
+        facts_unfresh = await pr_facts_calculator_no_cache(
             time_from,
             time_to,
             {"src-d/go-git"},
@@ -84,7 +84,7 @@ async def test_fetch_pull_request_facts_unfresh_smoke(
 
 @with_defer
 async def test_fetch_pull_request_facts_unfresh_labels(
-    metrics_calculator_factory,
+    pr_facts_calculator_factory,
     release_match_setting_tag,
     mdb,
     pdb,
@@ -92,11 +92,11 @@ async def test_fetch_pull_request_facts_unfresh_labels(
     prefixer,
     bots,
 ):
-    metrics_calculator_no_cache = metrics_calculator_factory(1, (6366825,))
+    pr_facts_calculator_no_cache = pr_facts_calculator_factory(1, (6366825,))
     time_from = datetime(2017, 9, 1, tzinfo=timezone.utc)
     time_to = datetime(2018, 11, 19, tzinfo=timezone.utc)
     label_filter = LabelFilter({"enhancement", "bug"}, set())
-    facts_fresh = await metrics_calculator_no_cache.calc_pull_request_facts_github(
+    facts_fresh = await pr_facts_calculator_no_cache(
         time_from,
         time_to,
         {"src-d/go-git"},
@@ -117,7 +117,7 @@ async def test_fetch_pull_request_facts_unfresh_labels(
     orig_threshold = entries.unfresh_prs_threshold
     entries.unfresh_prs_threshold = 1
     try:
-        facts_unfresh = await metrics_calculator_no_cache.calc_pull_request_facts_github(
+        facts_unfresh = await pr_facts_calculator_no_cache(
             time_from,
             time_to,
             {"src-d/go-git"},
@@ -141,7 +141,7 @@ async def test_fetch_pull_request_facts_unfresh_labels(
 
 @with_defer
 async def test_fetch_pull_request_facts_unfresh_jira(
-    metrics_calculator_factory,
+    pr_facts_calculator_factory,
     release_match_setting_tag,
     mdb,
     pdb,
@@ -149,7 +149,7 @@ async def test_fetch_pull_request_facts_unfresh_jira(
     prefixer,
     bots,
 ):
-    metrics_calculator_no_cache = metrics_calculator_factory(1, (6366825,))
+    pr_facts_calculator_no_cache = pr_facts_calculator_factory(1, (6366825,))
     time_from = datetime(2017, 9, 1, tzinfo=timezone.utc)
     time_to = datetime(2018, 11, 19, tzinfo=timezone.utc)
     jira_filter = JIRAFilter(
@@ -162,7 +162,7 @@ async def test_fetch_pull_request_facts_unfresh_jira(
         False,
         False,
     )
-    facts_fresh = await metrics_calculator_no_cache.calc_pull_request_facts_github(
+    facts_fresh = await pr_facts_calculator_no_cache(
         time_from,
         time_to,
         {"src-d/go-git"},
@@ -211,7 +211,7 @@ async def test_fetch_pull_request_facts_unfresh_jira(
     orig_threshold = entries.unfresh_prs_threshold
     entries.unfresh_prs_threshold = 1
     try:
-        facts_unfresh = await metrics_calculator_no_cache.calc_pull_request_facts_github(
+        facts_unfresh = await pr_facts_calculator_no_cache(
             time_from,
             time_to,
             {"src-d/go-git"},
@@ -254,7 +254,7 @@ async def test_fetch_pull_request_facts_unfresh_jira(
 # there are no precomputed PRs before `time_from`so count-s stay the same
 @with_defer
 async def test_fetch_pull_request_facts_unfresh_logical_title(
-    metrics_calculator_factory,
+    pr_facts_calculator_factory,
     release_match_setting_tag_logical,
     mdb,
     pdb,
@@ -266,10 +266,10 @@ async def test_fetch_pull_request_facts_unfresh_logical_title(
     exclude_inactive,
     count,
 ):
-    metrics_calculator_no_cache = metrics_calculator_factory(1, (6366825,))
+    pr_facts_calculator_no_cache = pr_facts_calculator_factory(1, (6366825,))
     time_from = datetime(2017, 9, 1, tzinfo=timezone.utc)
     time_to = datetime(2018, 11, 19, tzinfo=timezone.utc)
-    facts_fresh = await metrics_calculator_no_cache.calc_pull_request_facts_github(
+    facts_fresh = await pr_facts_calculator_no_cache(
         time_from,
         time_to,
         repos,
@@ -301,7 +301,7 @@ async def test_fetch_pull_request_facts_unfresh_logical_title(
     orig_threshold = entries.unfresh_prs_threshold
     entries.unfresh_prs_threshold = 1
     try:
-        facts_unfresh = await metrics_calculator_no_cache.calc_pull_request_facts_github(
+        facts_unfresh = await pr_facts_calculator_no_cache(
             time_from,
             time_to,
             repos,

--- a/server/tests/controllers/miners/github/test_precomputed_prs.py
+++ b/server/tests/controllers/miners/github/test_precomputed_prs.py
@@ -725,7 +725,7 @@ async def test_load_precomputed_done_times_reponums_smoke(
 @pytest.mark.parametrize("exclude_inactive", [False, True])
 @with_defer
 async def test_load_precomputed_done_times_deployments(
-    metrics_calculator_factory,
+    pr_facts_calculator_factory,
     mdb,
     pdb,
     rdb,
@@ -740,10 +740,10 @@ async def test_load_precomputed_done_times_deployments(
     precomputed_deployments,
     exclude_inactive,
 ):
-    metrics_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
+    pr_facts_calculator = pr_facts_calculator_factory(1, (6366825,), with_cache=True)
     time_from = datetime(2018, 1, 1, tzinfo=timezone.utc)
     time_to = datetime(2020, 5, 1, tzinfo=timezone.utc)
-    await metrics_calculator.calc_pull_request_facts_github(
+    await pr_facts_calculator(
         time_from,
         time_to,
         {"src-d/go-git"},
@@ -1671,7 +1671,7 @@ async def test_discover_update_unreleased_prs_deployments(
 
 @with_defer
 async def test_discover_old_merged_unreleased_prs_smoke(
-    metrics_calculator_factory,
+    pr_facts_calculator_factory,
     mdb,
     pdb,
     rdb,
@@ -1683,10 +1683,10 @@ async def test_discover_old_merged_unreleased_prs_smoke(
     release_loader,
     default_branches,
 ):
-    metrics_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
+    pr_facts_calculator = pr_facts_calculator_factory(1, (6366825,), with_cache=True)
     metrics_time_from = datetime(2018, 1, 1, tzinfo=timezone.utc)
     metrics_time_to = datetime(2020, 5, 1, tzinfo=timezone.utc)
-    await metrics_calculator.calc_pull_request_facts_github(
+    await pr_facts_calculator(
         metrics_time_from,
         metrics_time_to,
         {"src-d/go-git"},
@@ -1804,7 +1804,7 @@ async def test_discover_old_merged_unreleased_prs_smoke(
 
 @with_defer
 async def test_discover_old_merged_unreleased_prs_labels(
-    metrics_calculator_factory,
+    pr_facts_calculator_factory,
     mdb,
     pdb,
     rdb,
@@ -1813,10 +1813,10 @@ async def test_discover_old_merged_unreleased_prs_labels(
     bots,
     cache,
 ):
-    metrics_calculator = metrics_calculator_factory(1, (6366825,), with_cache=True)
+    pr_facts_calculator = pr_facts_calculator_factory(1, (6366825,), with_cache=True)
     metrics_time_from = datetime(2018, 5, 1, tzinfo=timezone.utc)
     metrics_time_to = datetime(2019, 1, 1, tzinfo=timezone.utc)
-    await metrics_calculator.calc_pull_request_facts_github(
+    await pr_facts_calculator(
         metrics_time_from,
         metrics_time_to,
         {"src-d/go-git"},

--- a/server/tests/controllers/miners/github/test_pull_request.py
+++ b/server/tests/controllers/miners/github/test_pull_request.py
@@ -1955,7 +1955,7 @@ async def test_fetch_prs_dead(mdb, pdb, branch_miner, pr_miner, prefixer):
 
 @with_defer
 async def test_mine_pull_requests_event_releases(
-    metrics_calculator_factory,
+    pr_facts_calculator_factory,
     release_match_setting_event,
     mdb,
     pdb,
@@ -1995,8 +1995,8 @@ async def test_mine_pull_requests_event_releases(
         False,
         0,
     )
-    calc = metrics_calculator_factory(1, (6366825,))
-    facts1 = await calc.calc_pull_request_facts_github(*args)
+    calc = pr_facts_calculator_factory(1, (6366825,))
+    facts1 = await calc(*args)
     facts1.sort_values(PullRequestFacts.f.created, inplace=True, ignore_index=True)
     await wait_deferred()
     await pdb.execute(
@@ -2012,6 +2012,6 @@ async def test_mine_pull_requests_event_releases(
             },
         ),
     )
-    facts2 = await calc.calc_pull_request_facts_github(*args)
+    facts2 = await calc(*args)
     facts2.sort_values(PullRequestFacts.f.created, inplace=True, ignore_index=True)
     assert_frame_equal(facts1.iloc[1:], facts2.iloc[1:])

--- a/server/tests/controllers/miners/github/test_release.py
+++ b/server/tests/controllers/miners/github/test_release.py
@@ -2332,13 +2332,13 @@ async def test_override_first_releases_smoke(
     prefixer,
     branches,
     default_branches,
-    metrics_calculator_factory,
+    pr_facts_calculator_factory,
     bots,
 ):
     time_from = datetime(year=2017, month=1, day=1, tzinfo=timezone.utc)
     time_to = datetime(year=2017, month=12, day=1, tzinfo=timezone.utc)
-    metrics_calculator_no_cache = metrics_calculator_factory(1, (6366825,))
-    await metrics_calculator_no_cache.calc_pull_request_facts_github(
+    pr_facts_calculator_no_cache = pr_facts_calculator_factory(1, (6366825,))
+    await pr_facts_calculator_no_cache(
         time_from,
         time_to,
         {"src-d/go-git"},

--- a/server/tests/controllers/test_filter_controller.py
+++ b/server/tests/controllers/test_filter_controller.py
@@ -92,7 +92,7 @@ async def test_filter_repositories_no_repos(client, headers):
 @pytest.mark.filter_repositories
 @with_defer
 async def test_filter_repositories_smoke(
-    metrics_calculator_factory,
+    pr_facts_calculator_factory,
     client,
     headers,
     mdb,
@@ -102,7 +102,7 @@ async def test_filter_repositories_smoke(
     prefixer,
     bots,
 ):
-    metrics_calculator_no_cache = metrics_calculator_factory(1, (6366825,))
+    pr_facts_calculator_no_cache = pr_facts_calculator_factory(1, (6366825,))
     time_from = datetime(2017, 9, 15, tzinfo=timezone.utc)
     time_to = datetime(2017, 9, 18, tzinfo=timezone.utc)
     args = (
@@ -120,7 +120,7 @@ async def test_filter_repositories_smoke(
         False,
         0,
     )
-    await metrics_calculator_no_cache.calc_pull_request_facts_github(*args)
+    await pr_facts_calculator_no_cache(*args)
     await wait_deferred()
     body = {
         "date_from": "2017-09-16",
@@ -145,14 +145,14 @@ async def test_filter_repositories_smoke(
 @pytest.mark.filter_repositories
 @with_defer
 async def test_filter_repositories_exclude_inactive_precomputed(
-    metrics_calculator_factory,
+    pr_facts_calculator_factory,
     client,
     headers,
     release_match_setting_tag,
     prefixer,
     bots,
 ):
-    metrics_calculator_no_cache = metrics_calculator_factory(1, (6366825,))
+    pr_facts_calculator_no_cache = pr_facts_calculator_factory(1, (6366825,))
     time_from = datetime(2017, 9, 15, tzinfo=timezone.utc)
     time_to = datetime(2017, 9, 18, tzinfo=timezone.utc)
     args = (
@@ -170,7 +170,7 @@ async def test_filter_repositories_exclude_inactive_precomputed(
         False,
         0,
     )
-    await metrics_calculator_no_cache.calc_pull_request_facts_github(*args)
+    await pr_facts_calculator_no_cache(*args)
     await wait_deferred()
     body = {
         "date_from": "2017-09-16",
@@ -280,7 +280,7 @@ async def test_filter_repositories_nasty_input(client, headers, account, date_to
 @pytest.mark.filter_repositories
 @with_defer
 async def test_filter_repositories_logical(
-    metrics_calculator_factory,
+    pr_facts_calculator_factory,
     client,
     headers,
     mdb,
@@ -293,7 +293,7 @@ async def test_filter_repositories_logical(
     logical_settings,
     logical_settings_db,
 ):
-    metrics_calculator_no_cache = metrics_calculator_factory(1, (6366825,))
+    pr_facts_calculator_no_cache = pr_facts_calculator_factory(1, (6366825,))
     time_from = datetime(2017, 9, 15, tzinfo=timezone.utc)
     time_to = datetime(2018, 1, 18, tzinfo=timezone.utc)
     args = (
@@ -311,7 +311,7 @@ async def test_filter_repositories_logical(
         False,
         0,
     )
-    await metrics_calculator_no_cache.calc_pull_request_facts_github(*args)
+    await pr_facts_calculator_no_cache(*args)
     await wait_deferred()
     body = {
         "date_from": "2017-09-16",
@@ -1960,13 +1960,13 @@ async def test_filter_prs_release_ignored(
     prefixer,
     branches,
     default_branches,
-    metrics_calculator_factory,
+    pr_facts_calculator_factory,
     bots,
 ):
     time_from = datetime(year=2017, month=1, day=1, tzinfo=timezone.utc)
     time_to = datetime(year=2017, month=12, day=1, tzinfo=timezone.utc)
-    metrics_calculator_no_cache = metrics_calculator_factory(1, (6366825,))
-    await metrics_calculator_no_cache.calc_pull_request_facts_github(
+    pr_facts_calculator_no_cache = pr_facts_calculator_factory(1, (6366825,))
+    await pr_facts_calculator_no_cache(
         time_from,
         time_to,
         {"src-d/go-git"},

--- a/server/tests/controllers/test_jira_controller.py
+++ b/server/tests/controllers/test_jira_controller.py
@@ -1179,7 +1179,7 @@ async def test_filter_jira_issue_prs_deployments(
     mdb_rw,
     precomputed_deployments,
     with_pdb,
-    metrics_calculator_factory,
+    pr_facts_calculator_factory,
     prefixer,
     release_match_setting_tag,
     bots,
@@ -1208,7 +1208,7 @@ async def test_filter_jira_issue_prs_deployments(
             False,
             0,
         )
-        await metrics_calculator_factory(1, (6366825,)).calc_pull_request_facts_github(*args)
+        await pr_facts_calculator_factory(1, (6366825,))(*args)
         await wait_deferred()
     await mdb_rw.execute_many(
         insert(NodePullRequestJiraIssues),
@@ -1781,12 +1781,12 @@ async def test_jira_metrics_bug_times(
     score,
     cmin,
     cmax,
-    metrics_calculator_factory,
+    pr_facts_calculator_factory,
     release_match_setting_tag,
     prefixer,
     bots,
 ):
-    metrics_calculator_no_cache = metrics_calculator_factory(1, (6366825,))
+    pr_facts_calculator_no_cache = pr_facts_calculator_factory(1, (6366825,))
     time_from = datetime(year=2018, month=1, day=1, tzinfo=timezone.utc)
     time_to = datetime(year=2020, month=4, day=1, tzinfo=timezone.utc)
     args = (
@@ -1804,7 +1804,7 @@ async def test_jira_metrics_bug_times(
         False,
         0,
     )
-    await metrics_calculator_no_cache.calc_pull_request_facts_github(*args)
+    await pr_facts_calculator_no_cache(*args)
     await wait_deferred()
     np.random.seed(7)
     body = {

--- a/server/tests/controllers/test_settings_controller.py
+++ b/server/tests/controllers/test_settings_controller.py
@@ -1359,7 +1359,7 @@ class TestSetLogicalRepository(Requester):
     @with_defer
     async def test_smoke(
         self,
-        metrics_calculator_factory,
+        pr_facts_calculator_factory,
         sdb,
         mdb,
         bots,
@@ -1367,11 +1367,11 @@ class TestSetLogicalRepository(Requester):
         prefixer,
         with_precomputed_reset_check,
     ):
-        metrics_calculator_no_cache = metrics_calculator_factory(1, (6366825,))
+        pr_facts_calculator_no_cache = pr_facts_calculator_factory(1, (6366825,))
         time_from = datetime(2016, 1, 1, tzinfo=timezone.utc)
         time_to = datetime(2021, 1, 1, tzinfo=timezone.utc)
         if with_precomputed_reset_check:
-            await metrics_calculator_no_cache.calc_pull_request_facts_github(
+            await pr_facts_calculator_no_cache(
                 time_from,
                 time_to,
                 {"src-d/go-git"},
@@ -1389,7 +1389,7 @@ class TestSetLogicalRepository(Requester):
             await wait_deferred()
         await self._test_set_logical_repository(sdb, 1)
         settings = Settings.from_account(1, prefixer, sdb, mdb, None, None)
-        df_post = await metrics_calculator_no_cache.calc_pull_request_facts_github(
+        df_post = await pr_facts_calculator_no_cache(
             time_from,
             time_to,
             {"src-d/go-git", "src-d/go-git/alpha"},

--- a/server/tests/internal/miners/jira/test_issue.py
+++ b/server/tests/internal/miners/jira/test_issue.py
@@ -45,7 +45,7 @@ class TestFetchJIRAIssues:
     @with_defer
     async def test_releases(
         self,
-        metrics_calculator_factory,
+        pr_facts_calculator_factory,
         mdb,
         pdb,
         rdb,
@@ -55,10 +55,10 @@ class TestFetchJIRAIssues:
         bots,
         cache,
     ):
-        metrics_calculator_no_cache = metrics_calculator_factory(1, (6366825,))
+        pr_facts_calculator_no_cache = pr_facts_calculator_factory(1, (6366825,))
         time_from = datetime(2016, 1, 1, tzinfo=timezone.utc)
         time_to = datetime(2021, 1, 1, tzinfo=timezone.utc)
-        await metrics_calculator_no_cache.calc_pull_request_facts_github(
+        await pr_facts_calculator_no_cache(
             time_from,
             time_to,
             {"src-d/go-git"},


### PR DESCRIPTION
Extract `PRFactsCalculator` from `MetricsCalculator`, so that only `PRFactsCalculator` is built when you only need to call `calc_pull_request_facts_github`