### PR TITLE
[DEV-5582] refactor db repositories access

### DIFF
--- a/server/athenian/api/align/goals/measure.py
+++ b/server/athenian/api/align/goals/measure.py
@@ -11,13 +11,13 @@ from athenian.api.align.goals.dbaccess import (
     GoalColumnAlias,
     TeamGoalColumns,
     convert_metric_params_datatypes,
-    resolve_goal_repositories,
 )
 from athenian.api.db import Row
 from athenian.api.internal.datetime_utils import datetimes_to_closed_dates_interval
 from athenian.api.internal.jira import JIRAConfig, check_jira_installation
 from athenian.api.internal.miners.filters import JIRAFilter, LabelFilter
 from athenian.api.internal.prefixer import Prefixer
+from athenian.api.internal.repos import dereference_db_repositories
 from athenian.api.internal.settings import LogicalRepositorySettings
 from athenian.api.internal.team_metrics import (
     CalcTeamMetricsRequest,
@@ -59,9 +59,7 @@ class _GoalTreeGenerator:
         if (repos := goal_row[GoalColumnAlias.REPOSITORIES.value]) is not None:
             repos = [
                 str(repo_name)
-                for repo_name in resolve_goal_repositories(
-                    repos, goal_row[Goal.id.name], prefixer, logical_settings,
-                )
+                for repo_name in dereference_db_repositories(repos, prefixer, logical_settings)
             ]
 
         team_goal = self._team_tree_to_team_goal_tree(team_tree, team_goal_rows_map, metric_values)
@@ -275,9 +273,7 @@ class GoalToServe:
                 goal_id = team_goal_row[TeamGoal.goal_id.name]
             repositories = team_goal_row[columns[TeamGoal.repositories.name]]
             if repositories is not None:
-                repo_names = resolve_goal_repositories(
-                    repositories, goal_id, prefixer, logical_settings,
-                )
+                repo_names = dereference_db_repositories(repositories, prefixer, logical_settings)
                 repositories = tuple(name.unprefixed for name in repo_names)
 
             jira_projects = team_goal_row[columns[TeamGoal.jira_projects.name]]

--- a/server/athenian/api/controllers/align/metric_controller.py
+++ b/server/athenian/api/controllers/align/metric_controller.py
@@ -118,7 +118,7 @@ def _parse_time_interval(metrics_request: TeamMetricsRequest) -> Intervals:
 
 
 async def _parse_repositories(
-    request_repos: Sequence[str],
+    request_repos: Sequence[str] | None,
     account_id: int,
     meta_ids: tuple[int, ...],
     request: AthenianWebRequest,

--- a/server/athenian/api/controllers/search_controller/search_prs.py
+++ b/server/athenian/api/controllers/search_controller/search_prs.py
@@ -15,7 +15,7 @@ import pandas as pd
 import sentry_sdk
 
 from athenian.api.async_utils import gather
-from athenian.api.db import DatabaseLike
+from athenian.api.db import Database
 from athenian.api.internal.account import get_metadata_account_ids
 from athenian.api.internal.features.entries import PRFactsCalculator
 from athenian.api.internal.features.github.pull_request_filter import (
@@ -180,9 +180,9 @@ class _SearchPRsReposSettings:
 
 @dataclasses.dataclass
 class _SearchPRsConnectors:
-    mdb: DatabaseLike
-    pdb: DatabaseLike
-    rdb: DatabaseLike
+    mdb: Database
+    pdb: Database
+    rdb: Database
     cache: Optional[aiomcache.Client]
 
 
@@ -305,7 +305,7 @@ class _OrderBy(metaclass=abc.ABCMeta):
     def apply_expression(
         self,
         expr: SearchPullRequestsOrderByExpression,
-        current_indexes: npt.NDarray[int],
+        current_indexes: npt.NDArray[int],
     ) -> tuple[npt.NDArray, npt.NDArray[int]]:
         """Parse an expression and return a tuple with ordered indexes and discard indexes.
 
@@ -319,7 +319,7 @@ class _OrderBy(metaclass=abc.ABCMeta):
     def _ordered_indexes(
         cls,
         expr: SearchPullRequestsOrderByExpression,
-        ordered_indexes: npt.NDarray[int],
+        ordered_indexes: npt.NDArray[int],
         values: npt.NDArray,
         nulls: npt.NDArray[int],
     ) -> npt.NDArray[int]:
@@ -385,7 +385,7 @@ class _OrderByMetrics(_OrderBy):
     def apply_expression(
         self,
         expr: SearchPullRequestsOrderByExpression,
-        current_indexes: npt.NDarray[int],
+        current_indexes: npt.NDArray[int],
     ) -> tuple[npt.NDArray, npt.NDArray[int]]:
         calc = self._calc_ensemble[expr.field][0]
         values = calc.peek[0][current_indexes]
@@ -412,7 +412,7 @@ class _OrderByStageTimings(_OrderBy):
         SearchPullRequestsOrderByStageTiming.PR_RELEASE_STAGE_TIMING.value: "release",
     }
 
-    def __init__(self, stage_timings: dict[str, npt.NDArray]):
+    def __init__(self, stage_timings: dict[str, list[npt.NDArray]]):
         self._stage_timings = stage_timings
 
     @classmethod
@@ -433,7 +433,7 @@ class _OrderByStageTimings(_OrderBy):
     def apply_expression(
         self,
         expr: SearchPullRequestsOrderByExpression,
-        current_indexes: npt.NDarray[int],
+        current_indexes: npt.NDArray[int],
     ) -> tuple[npt.NDArray, npt.NDArray[int]]:
         stage = self._FIELD_TO_STAGE[expr.field]
         values = self._stage_timings[stage][0][current_indexes]
@@ -452,7 +452,7 @@ class _OrderByTraits(_OrderBy):
     def apply_expression(
         self,
         expr: SearchPullRequestsOrderByExpression,
-        current_indexes: npt.NDarray[int],
+        current_indexes: npt.NDArray[int],
     ) -> tuple[npt.NDArray, npt.NDArray[int]]:
         values = self._get_values(expr).copy()[current_indexes]
         nulls = values != values

--- a/server/athenian/api/internal/logical_repos.py
+++ b/server/athenian/api/internal/logical_repos.py
@@ -8,11 +8,6 @@ def is_logical_repo(repo: str) -> bool:
     return repo.count("/") > 1
 
 
-def drop_prefixed_logical_repo(repo: str) -> str:
-    """Remove the logical part of the prefixed repository name."""
-    return "/".join(repo.split("/", 3)[:3])
-
-
 def coerce_logical_repos(repos: Iterable[str]) -> dict[str, set[str]]:
     """Remove the logical part of the repository names + deduplicate."""
     result: dict[str, set[str]] = {}
@@ -24,11 +19,3 @@ def coerce_logical_repos(repos: Iterable[str]) -> dict[str, set[str]]:
 def contains_logical_repos(repos: Iterable[str]) -> bool:
     """Check whether at least one repository name is logical."""
     return any(r.count("/") > 1 for r in repos)
-
-
-def extract_logical_repo(repo: str, offset: int = 2) -> str:
-    """Return the logical part of the repository name."""
-    try:
-        return repo.split("/", offset)[offset]
-    except IndexError:
-        return ""

--- a/server/athenian/api/internal/miners/github/pull_request.py
+++ b/server/athenian/api/internal/miners/github/pull_request.py
@@ -3122,7 +3122,7 @@ class PullRequestFactsMiner:
 
 async def fetch_prs_numbers(
     node_ids: npt.NDArray[int],
-    meta_ids: tuple[int],
+    meta_ids: tuple[int, ...],
     mdb: DatabaseLike,
 ) -> npt.NDArray[int]:
     """Given an array of PR node identifiers return an array with their PR numbers.

--- a/server/athenian/api/internal/repos.py
+++ b/server/athenian/api/internal/repos.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional, Sequence
+
+from athenian.api import metadata
+from athenian.api.internal.prefixer import Prefixer, RepositoryName, RepositoryReference
+from athenian.api.internal.settings import LogicalRepositorySettings
+
+
+def dereference_db_repositories(
+    repos: list[tuple[int, Optional[str]]],
+    prefixer: Prefixer,
+    logical_settings: LogicalRepositorySettings,
+) -> tuple[RepositoryName, ...]:
+    """Dereference the repository IDs into a RepositoryName sequence."""
+    references = parse_db_repositories(repos)
+    resolved = []
+    deleted_logical = []
+    for name in prefixer.dereference_repositories(references):
+        if name.logical and not logical_settings.repo_exists(name):
+            deleted_logical.append(str(name))
+            continue
+        resolved.append(name)
+    if deleted_logical:
+        if deleted_logical:
+            log = logging.getLogger(f"{metadata.__package__}.dereference_db_repositories")
+            log.warning("ignoring deleted logical repositories: %s", deleted_logical)
+    return tuple(resolved)
+
+
+def parse_db_repositories(
+    val: Optional[list[tuple[int, str | None]]],
+) -> Optional[list[RepositoryReference]]:
+    """Parse the raw value in DB repositories JSON column as list of `RepositoryReference`."""
+    if val is None:
+        return val
+    return [
+        RepositoryReference("github.com", repo_id, logical_name or "")
+        for repo_id, logical_name in val
+    ]
+
+
+def dump_db_repositories(
+    repo_idents: Optional[Sequence[RepositoryReference]],
+) -> Optional[list[tuple[int, str]]]:
+    """Dump the sequence of RepositoryReference-s in the format used by DB repositories JSON \
+    column."""
+    if repo_idents is None:
+        return None
+    return [(ident.node_id, ident.logical_name) for ident in repo_idents]

--- a/server/athenian/api/internal/settings.py
+++ b/server/athenian/api/internal/settings.py
@@ -630,6 +630,14 @@ class LogicalRepositorySettings:
                 continue
         return repos
 
+    def repo_exists(self, logical_repo: RepositoryName) -> bool:
+        """Return whether the logical repository exists."""
+        try:
+            physical_repo_settings = self.prs(logical_repo.unprefixed_physical)
+        except KeyError:
+            return False
+        return logical_repo.unprefixed in physical_repo_settings.logical_repositories
+
 
 class Settings:
     """

--- a/server/athenian/api/internal/settings.py
+++ b/server/athenian/api/internal/settings.py
@@ -573,7 +573,7 @@ class LogicalRepositorySettings:
             ),
         ).union(repos)
 
-    def prs(self, repo: str) -> Optional[LogicalPRSettings]:
+    def prs(self, repo: str) -> LogicalPRSettings:
         """Return PR match rules for the given repository native name."""
         return self._prs[repo]
 

--- a/server/athenian/api/models/state/models.py
+++ b/server/athenian/api/models/state/models.py
@@ -24,8 +24,9 @@ from sqlalchemy.dialects import sqlite
 from sqlalchemy.dialects.postgresql import JSONB
 
 from athenian.api.models import always_unequal, create_base
+from athenian.precomputer.db.base import BaseType
 
-Base = create_base()
+Base: BaseType = create_base()
 
 
 JSONType = JSONB().with_variant(JSON(), sqlite.dialect.name)

--- a/server/tests/controllers/test_prefixer.py
+++ b/server/tests/controllers/test_prefixer.py
@@ -145,6 +145,13 @@ class TestRepoIdentitiesMapper:
 
 def mk_prefixer(**kwargs: Any) -> Prefixer:
     """Construct a Prefixer to be used in tests."""
+
+    if "repo_node_to_prefixed_name" in kwargs and "repo_node_to_name" not in kwargs:
+        kwargs["repo_node_to_name"] = {
+            k: RepositoryName.from_prefixed(v).unprefixed
+            for k, v in kwargs["repo_node_to_prefixed_name"].items()
+        }
+
     for field in dataclasses.fields(Prefixer):
         if field.name != "do_not_construct_me_directly":
             kwargs.setdefault(field.name, {})

--- a/server/tests/internal/test_logical_repos.py
+++ b/server/tests/internal/test_logical_repos.py
@@ -2,16 +2,7 @@ from athenian.api.internal.logical_repos import (
     coerce_logical_repos,
     contains_logical_repos,
     drop_logical_repo,
-    drop_prefixed_logical_repo,
 )
-
-
-class TestDropPrefixedLogicalRepo:
-    def test(self) -> None:
-        assert drop_prefixed_logical_repo("github.com/org/repo/logical") == "github.com/org/repo"
-
-    def test_on_unprefixed(self) -> None:
-        assert drop_prefixed_logical_repo("org/repo/logical") == "org/repo/logical"
 
 
 def test_drop_logical_repo() -> None:

--- a/server/tests/internal/test_repos.py
+++ b/server/tests/internal/test_repos.py
@@ -1,0 +1,78 @@
+from athenian.api.internal.account import RepositoryReference
+from athenian.api.internal.prefixer import RepositoryName
+from athenian.api.internal.repos import (
+    dereference_db_repositories,
+    dump_db_repositories,
+    parse_db_repositories,
+)
+from athenian.api.internal.settings import LogicalRepositorySettings
+from tests.controllers.test_prefixer import mk_prefixer
+
+
+class TestParseDBRepositories:
+    def test_unset(self) -> None:
+        assert parse_db_repositories(None) is None
+
+    def test_empty(self) -> None:
+        assert parse_db_repositories([]) == []
+
+    def test_base(self) -> None:
+        val: list[list] = [[123, None], [456, "logical"]]
+        identities = parse_db_repositories(val)
+        assert identities is not None
+        assert all(isinstance(ident, RepositoryReference) for ident in identities)
+        assert identities[0].node_id == 123
+        assert identities[0].logical_name == ""
+        assert identities[1].node_id == 456
+        assert identities[1].logical_name == "logical"
+
+
+class TestDumpDBRepositories:
+    def test_none(self) -> None:
+        assert dump_db_repositories(None) is None
+
+    def test_some_identities(self) -> None:
+        idents = [
+            RepositoryReference("github.com", 1, "a"),
+            RepositoryReference("github.com", 2, ""),
+        ]
+        assert dump_db_repositories(idents) == [(1, "a"), (2, "")]
+
+
+class TestDereferenceDBRepositories:
+    def test_empty(self, logical_settings_full) -> None:
+        prefixer = mk_prefixer()
+        assert dereference_db_repositories([], prefixer, logical_settings_full) == ()
+
+    def test_base(self) -> None:
+        prefixer = mk_prefixer(
+            repo_node_to_prefixed_name={
+                1: "github.com/athenianco/a",
+                2: "github.com/athenianco/b",
+            },
+        )
+        logical_settings = LogicalRepositorySettings(
+            {
+                "athenianco/a": {"labels": ["a"]},
+                "athenianco/b": {"labels": ["b"]},
+                "athenianco/b/logic": {"labels": ["logic"]},
+            },
+            {},
+        )
+
+        res = dereference_db_repositories(
+            [(1, None), (2, None), (2, "logic"), (2, "xxx")], prefixer, logical_settings,
+        )
+
+        assert res == (
+            RepositoryName("github.com", "athenianco", "a", ""),
+            RepositoryName("github.com", "athenianco", "b", ""),
+            RepositoryName("github.com", "athenianco", "b", "logic"),
+        )
+
+    def test_unknown_ids_are_ignored(self) -> None:
+        prefixer = mk_prefixer(repo_node_to_prefixed_name={1: "github.com/athenianco/a"})
+        logical_settings = LogicalRepositorySettings({"athenianco/a": {"labels": ["a"]}}, {})
+        res = dereference_db_repositories([(1, None), (2, None)], prefixer, logical_settings)
+
+        assert res == (RepositoryName("github.com", "athenianco", "a", ""),)


### PR DESCRIPTION
Moved parse/dump/resolved goal repositories functions outside of goals module
Also use `prefixer.dereference_repositories(references)` in `dereference_db_repositories` to avoid code repetition
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/athenianco/athenian-api/3166)
<!-- Reviewable:end -->
