### PR TITLE
[DEV-5700] Update especifico to 3.0.28

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp[speedups]==3.8.3
-especifico[aiohttp,swagger-ui]==3.0.27
+especifico[aiohttp,swagger-ui]==3.0.28
 jsonschema==4.17.3
 aiohttp_cors==0.7.0
 swagger-ui-bundle==0.0.9


### PR DESCRIPTION
In order to avoid external HTTP request when serving private spec JSON.

https://github.com/athenianco/especifico/pull/110/files
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/athenianco/athenian-api/3222)
<!-- Reviewable:end -->
