### PR TITLE
[DEV-6064] Fix the error logging of non-string deployment names

### DIFF
--- a/server/athenian/api/internal/miners/github/deployment.py
+++ b/server/athenian/api/internal/miners/github/deployment.py
@@ -1393,9 +1393,9 @@ async def _generate_deployment_facts(
             for i, v in enumerate(releases[GitHubReleaseDeployment.deployment_name.name].values):
                 if not isinstance(v, str):
                     log.error(
-                        "non-string release name: %s %s",
+                        "non-string deployment name: %s %s",
                         v,
-                        releases[GitHubReleaseDeployment.deployment_name.name].iloc[i],
+                        releases.iloc[i],
                     )
             raise e from None
         release_order = np.argsort(release_index)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/athenianco/athenian-api/3391)
<!-- Reviewable:end -->
