### PR TITLE
[DEV-6100] Avoid zero division for jira-resolution-rate metric

### DIFF
--- a/server/athenian/api/internal/features/jira/issue_metrics.py
+++ b/server/athenian/api/internal/features/jira/issue_metrics.py
@@ -239,6 +239,7 @@ class ResolutionRateCalculator(RatioCalculator):
     """Calculate JIRA issues flow ratio = raised / resolved."""
 
     deps = (ResolvedCounter, RaisedCounter)
+    value_offset = 1
 
 
 @register_metric(JIRAMetricID.JIRA_LIFE_TIME)

--- a/server/tests/controllers/align/test_metric_controller.py
+++ b/server/tests/controllers/align/test_metric_controller.py
@@ -185,11 +185,11 @@ class TestTeamMetrics(BaseTeamMetricsTest):
                 "metric": "jira-resolution-rate",
                 "value": {
                     "team": {"id": 1, "name": "T1"},
-                    "value": 0.8908857703208923,
+                    "value": 0.8910256624221802,
                     "children": [
                         {
                             "team": {"id": 2, "name": "T2"},
-                            "value": 0.8571428656578064,
+                            "value": 0.8578947186470032,
                             "children": [],
                         },
                     ],

--- a/server/tests/controllers/jira_controller/test_calc_metrics_jira_linear.py
+++ b/server/tests/controllers/jira_controller/test_calc_metrics_jira_linear.py
@@ -294,7 +294,7 @@ class TestCalcMetricsJiraLinear(BaseCalcMetricsJiraLinearTest):
             (JIRAMetricID.JIRA_RESOLVED, True, 795),
             (JIRAMetricID.JIRA_ACKNOWLEDGED, False, 776),
             (JIRAMetricID.JIRA_ACKNOWLEDGED_Q, False, 776),
-            (JIRAMetricID.JIRA_RESOLUTION_RATE, False, 0.9578313231468201),
+            (JIRAMetricID.JIRA_RESOLUTION_RATE, False, 0.9578820466995239),
         ],
     )
     async def test_jira_metrics_counts(self, metric, exclude_inactive, n):


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/athenianco/athenian-api/3406)
<!-- Reviewable:end -->
