### PR TITLE
Make CI pass

### DIFF
--- a/server/athenian/api/application.py
+++ b/server/athenian/api/application.py
@@ -25,6 +25,7 @@ from aiohttp.web_exceptions import (
 )
 from aiohttp.web_runner import GracefulExit
 import aiohttp_cors
+import aiohttp_jinja2
 import aiomcache
 import asyncpg
 from asyncpg import InterfaceError, OperatorInterventionError, PostgresConnectionError
@@ -895,7 +896,7 @@ class AthenianApp(especifico.AioHttpApp):
     ):
         """Load the API spec and add the defined routes."""
         api = super().add_api(specification, ref_resolver_store=ref_resolver_store, **kwargs)
-        api.subapp["aiohttp_jinja2_environment"].autoescape = False
+        api.subapp[aiohttp_jinja2.APP_KEY].autoescape = False
         api.jsonifier.json = FriendlyJson
         for k, v in api.subapp.items():
             self.app[k] = v

--- a/server/athenian/api/kms.py
+++ b/server/athenian/api/kms.py
@@ -38,19 +38,32 @@ class AthenianKMS:
                     "%s must be defined, see https://cloud.google.com/kms/docs/reference/rest"
                     % env_names[0],
                 )
-        service_file_inline = os.getenv("GOOGLE_KMS_SERVICE_ACCOUNT_JSON_INLINE")
+
+        self._evars = evars
+
+        service_file_inline = os.getenv(
+            "GOOGLE_KMS_SERVICE_ACCOUNT_JSON_INLINE")
         if service_file_inline is not None:
-            service_file = io.StringIO(service_file_inline)
+            self._service_file = io.StringIO(service_file_inline)
         else:
-            service_file = os.getenv("GOOGLE_KMS_SERVICE_ACCOUNT_JSON")
-        self._kms = KMS(**evars, service_file=service_file)
-        self.log.info("Using Google KMS %(keyproject)s/%(keyring)s/%(keyname)s", evars)
+            self._service_file = os.getenv("GOOGLE_KMS_SERVICE_ACCOUNT_JSON")
+
+        self._kms = None
+        self.log.info(
+            "Using Google KMS %(keyproject)s/%(keyring)s/%(keyname)s", evars)
+
+    async def _get_kms(self) -> KMS:
+        if self._kms is None:
+            self._kms = KMS(**self._evars, service_file=self._service_file)
+
+        return self._kms
 
     async def encrypt(self, plaintext: Union[bytes, str]) -> str:
         """Encrypt text using Google KMS."""
+        kms = await self._get_kms()
         for attempt in range(self.timeout_retries):
             try:
-                return await self._kms.encrypt(encode(plaintext))
+                return await kms.encrypt(encode(plaintext))
             except asyncio.TimeoutError as e:
                 self.log.warning("encrypt attempt %d", attempt + 1)
                 if attempt == self.timeout_retries - 1:
@@ -59,9 +72,10 @@ class AthenianKMS:
     async def decrypt(self, ciphertext: str) -> bytes:
         """Decrypt text using Google KMS."""
         # we cannot use gcloud.aio.kms.decode because it converts bytes to string with str.decode()
+        kms = await self._get_kms()
         for attempt in range(self.timeout_retries):
             try:
-                payload = await self._kms.decrypt(ciphertext)
+                payload = await kms.decrypt(ciphertext)
             except asyncio.TimeoutError as e:
                 self.log.warning("decrypt attempt %d", attempt + 1)
                 if attempt == self.timeout_retries - 1:
@@ -72,4 +86,5 @@ class AthenianKMS:
 
     async def close(self):
         """Close the underlying HTTPS session."""
-        await self._kms.close()
+        if self._kms is not None:
+            await self._kms.close()

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools==75.3.0", "wheel", "Cython==3.0.12", "numpy==1.26.4"]
+requires = ["setuptools==75.3.0", "wheel", "Cython==3.0.12", "numpy==1.23.5"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/server/requirements-test.txt
+++ b/server/requirements-test.txt
@@ -12,3 +12,4 @@ filelock==3.10.6
 faker==18.4.0
 nest_asyncio==1.5.6
 factory-boy==3.2.1
+pandas==2.2.3

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp[speedups]==3.8.4
+aiohttp[speedups]==3.10.7
 especifico[aiohttp,swagger-ui]==3.0.31
 jsonschema==4.17.3
 aiohttp_cors==0.7.0

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -9,7 +9,7 @@ morcilla[sqlite,postgresql]==0.5.37
 psycopg2-binary==2.9.6
 xxhash==3.2.0
 # remember to change these versions in Dockerfile and pyproject.toml, too!
-numpy==1.26.4
+numpy==1.23.5
 # end of remember to change in Dockerfile
 scipy==1.10.1
 medvedi==0.1.68

--- a/server/tests/controllers/test_invitation_controller.py
+++ b/server/tests/controllers/test_invitation_controller.py
@@ -255,7 +255,7 @@ async def test_accept_invitation_smoke(client, headers, sdb, disable_default_use
     assert num_accounts_after == num_accounts_before
 
 
-@pytest.mark.flaky(reruns=5, reruns_delay=20)
+@pytest.mark.flaky(reruns=10, reruns_delay=30)
 async def test_accept_invitation_user_profile(
     client,
     headers,

--- a/server/tests/internal/miners/github/test_check_run_benchmark.py
+++ b/server/tests/internal/miners/github/test_check_run_benchmark.py
@@ -3,6 +3,7 @@ import logging
 from pathlib import Path
 import pickle
 
+import medvedi as md
 from medvedi.merge_to_str import merge_to_str
 import numpy as np
 import pandas as pd
@@ -249,6 +250,7 @@ def test_mine_check_runs_wrap(benchmark, no_deprecation_warnings):
     )
     for col in (
         CheckRun.started_at,
+        CheckRun.authored_date,
         CheckRun.completed_at,
         CheckRun.pull_request_created_at,
         CheckRun.pull_request_closed_at,
@@ -256,5 +258,17 @@ def test_mine_check_runs_wrap(benchmark, no_deprecation_warnings):
         check_suite_started_column,
     ):
         col_name = col.name if not isinstance(col, str) else col
-        df[col_name] = df[col_name].astype(np.datetime64)
-    benchmark(_finalize_check_runs, df, logging.getLogger("pytest.alternative_facts"))
+        df[col_name] = (
+            pd.to_datetime(df[col_name], format="ISO8601")
+            .dt.tz_localize(None)
+            .astype(np.dtype("datetime64[ns]"))
+        )
+
+    df[CheckRun.status.name] = df[CheckRun.status.name].astype("S")
+    df = md.DataFrame(df.to_dict("series"))
+
+    benchmark(
+        _finalize_check_runs,
+        df,
+        logging.getLogger("pytest.alternative_facts"),
+    )


### PR DESCRIPTION
## An update in the `yarl` package broke `aiohttp`

`aiohttp` relies on the `yarl` library for URL parsing and building. When running the tests, the majority of them fail due to a version of `yarl` that is incompatible with `aiohttp`.

The `yarl` requirement in `aiohttp==3.8.4` (current version we have in our requirements) is very loose: https://github.com/aio-libs/aiohttp/blob/v3.8.4/setup.cfg#L56

Indeed when inspecting the Docker container we can check using `pip freeze` that the version of `yarl` installed is `1.18.3`. This is the output of `pipdeptree`:
```
root@f7718d7499e7:/server# pipdeptree --reverse --packages yarl
yarl==1.18.3
└── aiohttp==3.8.4 [requires: yarl>=1.0,<2.0]
    ├── aiohttp-cors==0.7.0 [requires: aiohttp>=1.1]
    ├── aiohttp-jinja2==1.5.1 [requires: aiohttp>=3.6.3]
    ├── gcloud-aio-auth==4.2.1 [requires: aiohttp>=3.3.0,<4.0.0]
    │   ├── gcloud-aio-kms==4.2.0 [requires: gcloud-aio-auth>=3.1.0,<5.0.0]
    │   └── gcloud-aio-pubsub==5.4.0 [requires: gcloud-aio-auth>=3.3.0,<5.0.0]
    └── pytest-aiohttp==1.0.4 [requires: aiohttp>=3.8.1]
```

But after version `1.13` `yarl` changed how URLs are parsed in a way that port number cannot be part anymore of the `host` param when using `URL.build(...host=host)`, but needs to be used as `URL.build(...authority=host)`: https://github.com/aio-libs/aiohttp/issues/9307

This has been fixed in this PR: https://github.com/aio-libs/aiohttp/pull/9309

and has been shipped in version `3.10.7` which is the one being used in this PR.

## `numpy>=1.24`'s expired deprecations affect the way we initialize Dataframes

Currently we're using `numpy==1.26.4`. This is the release notes for `numpy>=1.24`: https://numpy.org/doc/2.2/release/1.24.0-notes.html#expired-deprecations

In particular:
```
Ragged array creation will now always raise a ValueError unless dtype=object is passed. This includes very deeply nested sequences.
```

This is the PR: https://github.com/numpy/numpy/pull/22004

We'd need to update how we use `md.DataFrame` everywhere and include `dtype=object` or make `medvedi` handle it. For now, to minimize the changes I'm downgrading to the latest `1.23` version.

## A test is still using `pandas` instead of `medvedi`

I don't know exactly the chronology of how this happens, but we have a test (`tests/internal/miners/github/test_check_run_benchmark.py`) that still relies on `pandas`.

With the same philosophy of trying to just make things work as they used to, I just added `pandas` as a test requirement and convert the `pd.DataFrame` to a `md.DataFrame` to reuse the downstream functions that have been already ported to be used with `medvedi`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/athenianco/athenian-api/3671)
<!-- Reviewable:end -->
